### PR TITLE
Feature/cldn 797

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -48,6 +48,18 @@ export interface Props {
   actions: Partial<ExploreActions> & Pick<ExploreActions, 'setControlValue'>;
 }
 
+const Button = styled.button`
+  background: none;
+  border: none;
+  text-decoration: underline;
+  color: blue;
+`;
+
+const ButtonContainer = styled.div`
+  text-align: center;
+  padding-top: 2px;
+`;
+
 const DatasourceContainer = styled.div`
   background-color: ${({ theme }) => theme.colors.grayscale.light4};
   position: relative;
@@ -264,9 +276,11 @@ export default function DataSourcePanel({
                 {t(`Showing %s of %s`, lists.metrics.length, lists.metrics.length)}
               </div>
               <DisplayMetrics metricList={lists.metrics} enableExploreDnd={enableExploreDnd} />
-              <button onClick={() => setShowAllMetrics(false)}>
-                Show less...
-              </button>
+              <ButtonContainer>
+                <Button onClick={() => setShowAllMetrics(false)}>
+                  Show less...
+                </Button>
+              </ButtonContainer>
             </>
             :
             <>
@@ -275,9 +289,11 @@ export default function DataSourcePanel({
               </div>
               <DisplayMetrics metricList={metricSlice} enableExploreDnd={enableExploreDnd} />
               { lists.metrics.length > 50 ?
-                <button onClick={() => setShowAllMetrics(true)}>
-                  Show all...
-                </button> : null
+                <ButtonContainer>
+                  <Button onClick={() => setShowAllMetrics(true)}>
+                    Show all...
+                  </Button> 
+                </ButtonContainer> : null
               }
             </>
           }
@@ -292,9 +308,11 @@ export default function DataSourcePanel({
                   {t("Showing %s of %s", lists.columns.length, lists.columns.length)}
                 </div>
                 <DisplayColumns columnList={lists.columns} enableExploreDnd={enableExploreDnd} />
-                <button onClick={() => setShowAllColumns(false)}>
-                  Show less...
-                </button>
+                <ButtonContainer>
+                  <Button onClick={() => setShowAllColumns(false)}>
+                    Show less...
+                  </Button>
+                </ButtonContainer>
               </>
               :
               <>
@@ -303,9 +321,11 @@ export default function DataSourcePanel({
                 </div>
                 <DisplayColumns columnList={columnSlice} enableExploreDnd={enableExploreDnd} />
                 { lists.columns.length > 50 ?
-                  <button onClick={() => setShowAllColumns(true)}>
-                    Show all...
-                  </button> : null
+                  <ButtonContainer>
+                    <Button onClick={() => setShowAllColumns(true)}>
+                      Show all...
+                    </Button>
+                  </ButtonContainer> : null
                 }
               </>
             }

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -52,7 +52,7 @@ const Button = styled.button`
   background: none;
   border: none;
   text-decoration: underline;
-  color: blue;
+  color: #1A85A0;
 `;
 
 const ButtonContainer = styled.div`

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -33,6 +33,7 @@ import { ExploreActions } from 'src/explore/actions/exploreActions';
 import Control from 'src/explore/components/Control';
 import DatasourcePanelDragWrapper from './DatasourcePanelDragWrapper';
 import { DndItemType } from '../DndItemType';
+import { setState } from 'react-jsonschema-form/lib/utils';
 
 interface DatasourceControl extends ControlConfig {
   datasource?: DatasourceMeta;
@@ -113,6 +114,7 @@ export default function DataSourcePanel({
 }: Props) {
   const { columns, metrics } = datasource;
   const [inputValue, setInputValue] = useState('');
+  const [showAll, setShowAll] = useState(false);
   const [lists, setList] = useState({
     columns,
     metrics,
@@ -180,6 +182,9 @@ export default function DataSourcePanel({
     setInputValue('');
   }, [columns, datasource, metrics]);
 
+  const metricSlice = lists.metrics.slice(0, 50);
+  const columnSlice = lists.columns.slice(0, 50);
+
   const mainBody = (
     <>
       <div className="field-selections" style={{overflowY: 'scroll', height: '88%'}}>
@@ -225,23 +230,77 @@ export default function DataSourcePanel({
             header={<span className="header">{t('Columns')}</span>}
             key="column"
           >
-            <div className="field-length">
-              {t(`Showing %s`, lists.columns.length)}
-            </div>
-            {lists.columns.map(col => (
-              <LabelContainer key={col.column_name} className="column">
-                {enableExploreDnd ? (
-                  <DatasourcePanelDragWrapper
-                    value={col}
-                    type={DndItemType.Column}
-                  >
-                    <ColumnOption column={col} showType />
-                  </DatasourcePanelDragWrapper>
-                ) : (
-                  <ColumnOption column={col} showType />
-                )}
-              </LabelContainer>
-            ))}
+            { lists.columns.length > 50 ? 
+              <>
+                { showAll ?
+                  <>
+                    <div className="field-length">
+                      {t(`Showing %s`, lists.columns.length)}
+                    </div>
+                    {lists.columns.map(col => (
+                      <LabelContainer key={col.column_name} className="column">
+                        {enableExploreDnd ? (
+                          <DatasourcePanelDragWrapper
+                            value={col}
+                            type={DndItemType.Column}
+                          >
+                            <ColumnOption column={col} showType />
+                          </DatasourcePanelDragWrapper>
+                        ) : (
+                          <ColumnOption column={col} showType />
+                        )}
+                      </LabelContainer>
+                    ))}
+                    <button onClick={() => setShowAll(false)}>
+                      Show less...
+                    </button>
+                  </>
+                  :
+                  <>
+                    <div className="field-length">
+                      {t(`Showing %s of %s`, columnSlice.length, lists.columns.length)}
+                    </div>
+                    {columnSlice.map(col => (
+                      <LabelContainer key={col.column_name} className="column">
+                        {enableExploreDnd ? (
+                          <DatasourcePanelDragWrapper
+                            value={col}
+                            type={DndItemType.Column}
+                          >
+                            <ColumnOption column={col} showType />
+                          </DatasourcePanelDragWrapper>
+                        ) : (
+                          <ColumnOption column={col} showType />
+                        )}
+                      </LabelContainer>
+                    ))}
+                    <button onClick={() => setShowAll(true)}>
+                      Show more...
+                    </button>
+                  </>
+                }
+              </>
+              :
+              <>
+                <div className="field-length">
+                  {t(`Showing %s`, lists.columns.length)}
+                </div>
+                {lists.columns.map(col => (
+                  <LabelContainer key={col.column_name} className="column">
+                    {enableExploreDnd ? (
+                      <DatasourcePanelDragWrapper
+                        value={col}
+                        type={DndItemType.Column}
+                      >
+                        <ColumnOption column={col} showType />
+                      </DatasourcePanelDragWrapper>
+                    ) : (
+                      <ColumnOption column={col} showType />
+                    )}
+                  </LabelContainer>
+                ))}
+              </>
+            }
           </Collapse.Panel>
         </Collapse>
       </div>

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -276,7 +276,7 @@ export default function DataSourcePanel({
               <DisplayMetrics metricList={metricSlice} enableExploreDnd={enableExploreDnd} />
               { lists.metrics.length > 50 ?
                 <button onClick={() => setShowAllMetrics(true)}>
-                  Show more...
+                  Show all...
                 </button> : null
               }
             </>
@@ -304,7 +304,7 @@ export default function DataSourcePanel({
                 <DisplayColumns columnList={columnSlice} enableExploreDnd={enableExploreDnd} />
                 { lists.columns.length > 50 ?
                   <button onClick={() => setShowAllColumns(true)}>
-                    Show more...
+                    Show all...
                   </button> : null
                 }
               </>

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -24,6 +24,8 @@ import {
   MetricOption,
   ControlConfig,
   DatasourceMeta,
+  ColumnMeta,
+  Metric
 } from '@superset-ui/chart-controls';
 import { debounce } from 'lodash';
 import { matchSorter, rankings } from 'match-sorter';
@@ -106,6 +108,54 @@ const enableExploreDnd = isFeatureEnabled(
   FeatureFlag.ENABLE_EXPLORE_DRAG_AND_DROP,
 );
 
+export type DisplayColumnsProps = {
+  columnList: Array<ColumnMeta>;
+  enableExploreDnd: boolean;
+}
+
+export const DisplayColumns = ({ columnList, enableExploreDnd } : DisplayColumnsProps) => 
+  <>
+    {columnList.map(col => (
+      <LabelContainer key={col.column_name} className="column">
+        {enableExploreDnd ? (
+          <DatasourcePanelDragWrapper 
+            value={col}
+            type={DndItemType.Column}
+          >
+            <ColumnOption column={col} showType />
+          </DatasourcePanelDragWrapper>
+        ): (
+          <ColumnOption column={col} showType />
+        )}
+      </LabelContainer>
+    ))}
+  </>
+
+
+export type DisplayMetricsProps = {
+  metricList: Array<Metric>;
+  enableExploreDnd: Boolean;
+}
+
+export const DisplayMetrics = ({ metricList, enableExploreDnd }: DisplayMetricsProps) => 
+  <>
+    {metricList.map(m => (
+      <LabelContainer key={m.metric_name} className="column">
+        {enableExploreDnd ? (
+          <DatasourcePanelDragWrapper
+            value={m}
+            type={DndItemType.Metric}
+          >
+            <MetricOption metric={m} showType />
+          </DatasourcePanelDragWrapper>
+        ) : (
+          <MetricOption metric={m} showType />
+        )}
+      </LabelContainer>
+    ))}
+  </>
+
+
 export default function DataSourcePanel({
   datasource,
   controls: { datasource: datasourceControl },
@@ -113,7 +163,8 @@ export default function DataSourcePanel({
 }: Props) {
   const { columns, metrics } = datasource;
   const [inputValue, setInputValue] = useState('');
-  const [showAll, setShowAll] = useState(false);
+  const [showAllMetrics, setShowAllMetrics] = useState(false);
+  const [showAllColumns, setShowAllColumns] = useState(false);
   const [lists, setList] = useState({
     columns,
     metrics,
@@ -207,145 +258,55 @@ export default function DataSourcePanel({
             header={<span className="header">{t('Metrics')}</span>}
             key="metrics"
           >
-            { lists.metrics.length > 50 ?
-              <>
-                { showAll ?
-                  <>
-                    <div className="field-length">
-                      {t(`Showing %s`, lists.metrics.length)}
-                    </div>
-                    {lists.metrics.map(m => (
-                      <LabelContainer key={m.metric_name} className="column">
-                        {enableExploreDnd ? (
-                          <DatasourcePanelDragWrapper
-                            value={m}
-                            type={DndItemType.Metric}
-                          >
-                            <MetricOption metric={m} showType />
-                          </DatasourcePanelDragWrapper>
-                        ) : (
-                          <MetricOption metric={m} showType />
-                        )}
-                      </LabelContainer>
-                    ))}
-                  </>
-                  :
-                  <>
-                    <div className="field-length">
-                      {t(`Showing %s of %s`, metricSlice.length, lists.metrics.length)}
-                    </div>
-                    {metricSlice.map(m => (
-                      <LabelContainer key={m.metric_name} className="column">
-                        {enableExploreDnd ? (
-                          <DatasourcePanelDragWrapper
-                            value={m}
-                            type={DndItemType.Metric}
-                          >
-                            <MetricOption metric={m} showType />
-                          </DatasourcePanelDragWrapper>
-                        ) : (
-                          <MetricOption metric={m} showType />
-                        )}
-                      </LabelContainer>
-                    ))}
-                  </>
-                }
-              </>
-              :
-              <>
-                <div className="field-length">
-                  {t(`Showing %s`, lists.metrics.length)}
-                </div>
-                {lists.metrics.map(m => (
-                  <LabelContainer key={m.metric_name} className="column">
-                    {enableExploreDnd ? (
-                      <DatasourcePanelDragWrapper
-                        value={m}
-                        type={DndItemType.Metric}
-                      >
-                        <MetricOption metric={m} showType />
-                      </DatasourcePanelDragWrapper>
-                    ) : (
-                      <MetricOption metric={m} showType />
-                    )}
-                  </LabelContainer>
-                ))}
-              </>
-            }
+          { showAllMetrics ?
+            <>
+              <div className="field-length">
+                {t(`Showing %s of %s`, lists.metrics.length, lists.metrics.length)}
+              </div>
+              <DisplayMetrics metricList={lists.metrics} enableExploreDnd={enableExploreDnd} />
+              <button onClick={() => setShowAllMetrics(false)}>
+                Show less...
+              </button>
+            </>
+            :
+            <>
+              <div className="field-length">
+                {t(`Showing %s of %s`, metricSlice.length, lists.metrics.length)}
+              </div>
+              <DisplayMetrics metricList={metricSlice} enableExploreDnd={enableExploreDnd} />
+              { lists.metrics.length > 50 ?
+                <button onClick={() => setShowAllMetrics(true)}>
+                  Show more...
+                </button> : null
+              }
+            </>
+          }
           </Collapse.Panel>
           <Collapse.Panel
             header={<span className="header">{t('Columns')}</span>}
             key="column"
           >
-            { lists.columns.length > 50 ? 
+            { showAllColumns ? 
               <>
-                { showAll ?
-                  <>
-                    <div className="field-length">
-                      {t(`Showing %s`, lists.columns.length)}
-                    </div>
-                    {lists.columns.map(col => (
-                      <LabelContainer key={col.column_name} className="column">
-                        {enableExploreDnd ? (
-                          <DatasourcePanelDragWrapper
-                            value={col}
-                            type={DndItemType.Column}
-                          >
-                            <ColumnOption column={col} showType />
-                          </DatasourcePanelDragWrapper>
-                        ) : (
-                          <ColumnOption column={col} showType />
-                        )}
-                      </LabelContainer>
-                    ))}
-                    <button onClick={() => setShowAll(false)}>
-                      Show less...
-                    </button>
-                  </>
-                  :
-                  <>
-                    <div className="field-length">
-                      {t(`Showing %s of %s`, columnSlice.length, lists.columns.length)}
-                    </div>
-                    {columnSlice.map(col => (
-                      <LabelContainer key={col.column_name} className="column">
-                        {enableExploreDnd ? (
-                          <DatasourcePanelDragWrapper
-                            value={col}
-                            type={DndItemType.Column}
-                          >
-                            <ColumnOption column={col} showType />
-                          </DatasourcePanelDragWrapper>
-                        ) : (
-                          <ColumnOption column={col} showType />
-                        )}
-                      </LabelContainer>
-                    ))}
-                    <button onClick={() => setShowAll(true)}>
-                      Show more...
-                    </button>
-                  </>
-                }
+                <div className="field-length">
+                  {t("Showing %s of %s", lists.columns.length, lists.columns.length)}
+                </div>
+                <DisplayColumns columnList={lists.columns} enableExploreDnd={enableExploreDnd} />
+                <button onClick={() => setShowAllColumns(false)}>
+                  Show less...
+                </button>
               </>
               :
               <>
                 <div className="field-length">
-                  {t(`Showing %s`, lists.columns.length)}
+                  {t("Showing %s of %s", columnSlice.length, lists.columns.length)}
                 </div>
-                {lists.columns.map(col => (
-                  <LabelContainer key={col.column_name} className="column">
-                    {enableExploreDnd ? (
-                      <DatasourcePanelDragWrapper
-                        value={col}
-                        type={DndItemType.Column}
-                      >
-                        <ColumnOption column={col} showType />
-                      </DatasourcePanelDragWrapper>
-                    ) : (
-                      <ColumnOption column={col} showType />
-                    )}
-                  </LabelContainer>
-                ))}
+                <DisplayColumns columnList={columnSlice} enableExploreDnd={enableExploreDnd} />
+                { lists.columns.length > 50 ?
+                  <button onClick={() => setShowAllColumns(true)}>
+                    Show more...
+                  </button> : null
+                }
               </>
             }
           </Collapse.Panel>

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -52,7 +52,7 @@ const Button = styled.button`
   background: none;
   border: none;
   text-decoration: underline;
-  color: #1A85A0;
+  color: ${({ theme }) => theme.colors.primary.dark1};
 `;
 
 const ButtonContainer = styled.div`

--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -33,7 +33,6 @@ import { ExploreActions } from 'src/explore/actions/exploreActions';
 import Control from 'src/explore/components/Control';
 import DatasourcePanelDragWrapper from './DatasourcePanelDragWrapper';
 import { DndItemType } from '../DndItemType';
-import { setState } from 'react-jsonschema-form/lib/utils';
 
 interface DatasourceControl extends ControlConfig {
   datasource?: DatasourceMeta;
@@ -208,23 +207,71 @@ export default function DataSourcePanel({
             header={<span className="header">{t('Metrics')}</span>}
             key="metrics"
           >
-            <div className="field-length">
-              {t(`Showing %s`, lists.metrics.length)}
-            </div>
-            {lists.metrics.map(m => (
-              <LabelContainer key={m.metric_name} className="column">
-                {enableExploreDnd ? (
-                  <DatasourcePanelDragWrapper
-                    value={m}
-                    type={DndItemType.Metric}
-                  >
-                    <MetricOption metric={m} showType />
-                  </DatasourcePanelDragWrapper>
-                ) : (
-                  <MetricOption metric={m} showType />
-                )}
-              </LabelContainer>
-            ))}
+            { lists.metrics.length > 50 ?
+              <>
+                { showAll ?
+                  <>
+                    <div className="field-length">
+                      {t(`Showing %s`, lists.metrics.length)}
+                    </div>
+                    {lists.metrics.map(m => (
+                      <LabelContainer key={m.metric_name} className="column">
+                        {enableExploreDnd ? (
+                          <DatasourcePanelDragWrapper
+                            value={m}
+                            type={DndItemType.Metric}
+                          >
+                            <MetricOption metric={m} showType />
+                          </DatasourcePanelDragWrapper>
+                        ) : (
+                          <MetricOption metric={m} showType />
+                        )}
+                      </LabelContainer>
+                    ))}
+                  </>
+                  :
+                  <>
+                    <div className="field-length">
+                      {t(`Showing %s of %s`, metricSlice.length, lists.metrics.length)}
+                    </div>
+                    {metricSlice.map(m => (
+                      <LabelContainer key={m.metric_name} className="column">
+                        {enableExploreDnd ? (
+                          <DatasourcePanelDragWrapper
+                            value={m}
+                            type={DndItemType.Metric}
+                          >
+                            <MetricOption metric={m} showType />
+                          </DatasourcePanelDragWrapper>
+                        ) : (
+                          <MetricOption metric={m} showType />
+                        )}
+                      </LabelContainer>
+                    ))}
+                  </>
+                }
+              </>
+              :
+              <>
+                <div className="field-length">
+                  {t(`Showing %s`, lists.metrics.length)}
+                </div>
+                {lists.metrics.map(m => (
+                  <LabelContainer key={m.metric_name} className="column">
+                    {enableExploreDnd ? (
+                      <DatasourcePanelDragWrapper
+                        value={m}
+                        type={DndItemType.Metric}
+                      >
+                        <MetricOption metric={m} showType />
+                      </DatasourcePanelDragWrapper>
+                    ) : (
+                      <MetricOption metric={m} showType />
+                    )}
+                  </LabelContainer>
+                ))}
+              </>
+            }
           </Collapse.Panel>
           <Collapse.Panel
             header={<span className="header">{t('Columns')}</span>}


### PR DESCRIPTION
Caps the number of columns and metrics in the data set explore window to 50 initially before a user clicks a show more button that displays the rest.
