### PR TITLE
CLDN-941: some grid settings not functioning

### DIFF
--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/controlPanel.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/controlPanel.ts
@@ -21,7 +21,6 @@ import {
   validateNonEmpty, FeatureFlag, isFeatureEnabled,
   QueryMode,
   QueryFormColumn,
-//  ChartDataResponseResult,
 } from '@superset-ui/core';
 import {
   ControlConfig,
@@ -320,8 +319,8 @@ const config: ControlPanelConfig = {
   },
 };
 
-// CLDN-941: Only show the CUSTOMIZE tab if DASHBOARD_CROSS_FILTERS are enabled in the system
-// when more customization is added in the future this code can be removed and the code above
+// CLDN-941: Only show the CUSTOMIZE tab if DASHBOARD_CROSS_FILTERS are enabled in the system.
+// When more customization is added in the future this code can be removed and the code above
 // can be re-enabled.
 if (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {
   config.controlPanelSections.push({

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/controlPanel.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/controlPanel.ts
@@ -21,7 +21,7 @@ import {
   validateNonEmpty, FeatureFlag, isFeatureEnabled,
   QueryMode,
   QueryFormColumn,
-  ChartDataResponseResult,
+//  ChartDataResponseResult,
 } from '@superset-ui/core';
 import {
   ControlConfig,
@@ -230,79 +230,81 @@ const config: ControlPanelConfig = {
       ],
 
     },
-    {
-      label: t('CCCS Grid Options'),
-      expanded: true,
-      controlSetRows: [
-        [
-          {
-            name: 'bold_text',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Bold Text'),
-              renderTrigger: true,
-              default: true,
-              description: t('A checkbox to make the '),
-            },
-          },
-        ],
-        isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)
-        ? [
-            {
-              name: 'table_filter',
-              config: {
-                type: 'CheckboxControl',
-                label: t('Enable emitting filters'),
-                default: false,
-                renderTrigger: true,
-                description: t('Whether to apply filter to dashboards when grid cells are clicked.'),
-              },
-            },
-          ] : []
-        ,
-        [
-          {
-            name: 'column_config',
-            config: {
-              type: 'ColumnConfigControl',
-              label: t('Customize columns'),
-              description: t('Further customize how to display each column'),
-              renderTrigger: true,
-              mapStateToProps(explore, control, chart) {
-                return {
-                  queryResponse: chart?.queriesResponse?.[0] as ChartDataResponseResult | undefined,
-                  emitFilter: explore?.controls?.table_filter?.value,
-                };
-              },
-            },
-          },
-        ],
-        [
-          {
-            name: 'header_font_size',
-            config: {
-              type: 'SelectControl',
-              label: t('Font Size'),
-              default: 'xl',
-              choices: [
-                // [value, label]
-                ['xxs', 'xx-small'],
-                ['xs', 'x-small'],
-                ['s', 'small'],
-                ['m', 'medium'],
-                ['l', 'large'],
-                ['xl', 'x-large'],
-                ['xxl', 'xx-large'],
-              ],
-              renderTrigger: true,
-              description: t('The size of your header font'),
-            },
-          },
-        ],
-      ],
-    },
+    // For CLDN-941: hiding away options that are not hooked up to the ag-grid, moving all to a block that
+    // will hide / show the tab based on DASHBOARD_CROSS_FILTERS being enabled since that's the only option
+    // that is working.
+    // {
+    //   label: t('CCCS Grid Options'),
+    //   expanded: true,
+    //   controlSetRows: [
+    //     [
+    //       {
+    //         name: 'bold_text',
+    //         config: {
+    //           type: 'CheckboxControl',
+    //           label: t('Bold Text'),
+    //           renderTrigger: true,
+    //           default: true,
+    //           description: t('A checkbox to make the '),
+    //         },
+    //       },
+    //     ],
+    //     isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)
+    //     ? [
+    //         {
+    //           name: 'table_filter',
+    //           config: {
+    //             type: 'CheckboxControl',
+    //             label: t('Enable emitting filters'),
+    //             default: false,
+    //             renderTrigger: true,
+    //             description: t('Whether to apply filter to dashboards when grid cells are clicked.'),
+    //           },
+    //         },
+    //       ] : []
+    //     ,
+    //     [
+    //       {
+    //         name: 'column_config',
+    //         config: {
+    //           type: 'ColumnConfigControl',
+    //           label: t('Customize columns'),
+    //           description: t('Further customize how to display each column'),
+    //           renderTrigger: true,
+    //           mapStateToProps(explore, control, chart) {
+    //             return {
+    //               queryResponse: chart?.queriesResponse?.[0] as ChartDataResponseResult | undefined,
+    //               emitFilter: explore?.controls?.table_filter?.value,
+    //             };
+    //           },
+    //         },
+    //       },
+    //     ],
+    //     [
+    //       {
+    //         name: 'header_font_size',
+    //         config: {
+    //           type: 'SelectControl',
+    //           label: t('Font Size'),
+    //           default: 'xl',
+    //           choices: [
+    //             // [value, label]
+    //             ['xxs', 'xx-small'],
+    //             ['xs', 'x-small'],
+    //             ['s', 'small'],
+    //             ['m', 'medium'],
+    //             ['l', 'large'],
+    //             ['xl', 'x-large'],
+    //             ['xxl', 'xx-large'],
+    //           ],
+    //           renderTrigger: true,
+    //           description: t('The size of your header font'),
+    //         },
+    //       },
+    //     ],
+    //   ],
+    // },
   ],
-
   // override controls that are inherited by the default configuration
   controlOverrides: {
     series: {
@@ -317,5 +319,29 @@ const config: ControlPanelConfig = {
     },
   },
 };
+
+// CLDN-941: Only show the CUSTOMIZE tab if DASHBOARD_CROSS_FILTERS are enabled in the system
+// when more customization is added in the future this code can be removed and the code above
+// can be re-enabled.
+if (isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)) {
+  config.controlPanelSections.push({
+    label: t('CCCS Grid Options'),
+    expanded: true,
+    controlSetRows: [
+      [
+        {
+          name: 'table_filter',
+          config: {
+            type: 'CheckboxControl',
+            label: t('Enable emitting filters'),
+            default: false,
+            renderTrigger: true,
+            description: t('Whether to apply filter to dashboards when grid cells are clicked.'),
+          },
+        },
+      ],
+    ]
+  });
+}
 
 export default config;


### PR DESCRIPTION

### SUMMARY
As discussed:
- I've removed the customize features that were not functioning
- I've moved the one enable emitting filters out on it's own
- The customize tab will only be shown when cross filters are enabled


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before my change without cross filters
![BeforeChangeWithoutCrossFilters](https://user-images.githubusercontent.com/65294587/131852924-fdb7c23f-a2cb-484f-848c-dd2f53c61408.PNG)
After my change without cross filters
![AfterChangeWithoutCrossFilters](https://user-images.githubusercontent.com/65294587/131852906-b8ba222f-d431-4c4c-8d0d-cbfdfdcfa576.PNG)

Before my change with cross filters
![BeforeChangeWithCrossFilters](https://user-images.githubusercontent.com/65294587/131852914-74f0f3e2-72e6-4d6b-9b62-a08e357c11ac.png)
After my change with cross filters
![AfterChangeWithCrossFilters](https://user-images.githubusercontent.com/65294587/131852898-b57fc7c6-7344-4279-9645-1315a5324b85.PNG)

### TEST PLAN
Try the product with cross filters turned on and off.  The customize section for the chart should enable when cross filters are turned off and should not be present when cross filters are turned off.

Ensure cross filtering continues to work when the CCCS-Grid is used in a dashboard

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [X] Has associated issue: CLDN-941
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [X] Removes existing feature or API - UI disappears from the product, the UI was not functioning.
