### PR TITLE
CLDN-988: Modified to line to pick sqlAlchemy-trino fix that handles …

### DIFF
--- a/cccs-build/superset/requirements.txt
+++ b/cccs-build/superset/requirements.txt
@@ -5,6 +5,9 @@ authlib==0.15.4
 python-json-logger==2.0.2
 
 # Additional drivers for Superset (or SQLAlchemy) to use
-sqlalchemy-trino==0.3.0
+# uncomment and update release number when pr https://github.com/dungdm93/sqlalchemy-trino/pull/22 is merged.
+# sqlalchemy-trino==0.3.0
+# In the meantime, use following line
+git+https://github.com/cccs-mmrouet/sqlalchemy-trino.git@feature/timestamp-fix
 mysql-connector-python==8.0.26
 elasticsearch-dbapi==0.2.4


### PR DESCRIPTION
…timestamps with time zone.

### SUMMARY
Change to pick up a change in https://github.com/cccs-mmrouet/sqlalchemy-trino.git@feature/timestamp-fix
that handles timestamps with timezone.