### PR TITLE
Change datatype of column type in BaseColumn to allow larger datatype names for complexed columns

### DIFF
--- a/superset/connectors/base/models.py
+++ b/superset/connectors/base/models.py
@@ -558,7 +558,7 @@ class BaseColumn(AuditMixinNullable, ImportExportMixin):
     column_name = Column(String(255), nullable=False)
     verbose_name = Column(String(1024))
     is_active = Column(Boolean, default=True)
-    type = Column(String(32))
+    type = Column(Text)
     groupby = Column(Boolean, default=True)
     filterable = Column(Boolean, default=True)
     description = Column(Text)

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -42,7 +42,7 @@ def validate_python_date_format(value: str) -> None:
 class DatasetColumnsPutSchema(Schema):
     id = fields.Integer()
     column_name = fields.String(required=True, validate=Length(1, 255))
-    type = fields.String(validate=Length(1, 32))
+    type = fields.String(allow_none=True)
     verbose_name = fields.String(allow_none=True, Length=(1, 1024))
     description = fields.String(allow_none=True)
     expression = fields.String(allow_none=True)

--- a/superset/migrations/versions/3ba29ecbaac5_change_datatype_of_type_in_basecolumn.py
+++ b/superset/migrations/versions/3ba29ecbaac5_change_datatype_of_type_in_basecolumn.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Change datatype of type in BaseColumn
+
+Revision ID: 3ba29ecbaac5
+Revises: b92d69a6643c
+Create Date: 2021-11-02 17:44:51.792138
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3ba29ecbaac5'
+down_revision = 'b92d69a6643c'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+
+    with op.batch_alter_table("table_columns") as batch_op:
+        batch_op.alter_column(
+            "type", existing_type=sa.VARCHAR(length=32), type_=sa.TEXT()
+        )
+
+def downgrade():
+    with op.batch_alter_table("table_columns") as batch_op:
+        batch_op.alter_column(
+            "type", existing_type=sa.TEXT(), type_=sa.VARCHAR(length=32)
+        )


### PR DESCRIPTION
*** This won't be merged to master in our org, the idea is to have a pre code review and make another PR upstream for a contribution ***

### SUMMARY
Some columns such as the ones representing a complex structure (array, struct, enum or a combination of these) may require more than 32 chars to store the datatype. Changing datatype to TEXT and no limit was suggested by a Superset dev in the 1st associated issue listed below.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://user-images.githubusercontent.com/62111795/139951814-d970e5aa-4934-490a-8eb7-44f4d85ac7f3.png)
After:
![image](https://user-images.githubusercontent.com/62111795/139951549-015275c5-a337-488e-97cc-5842e65e22b5.png)

### TESTING INSTRUCTIONS
After the migration, easiest way to test is to edit an existing dataset and change the type value of a column (using the legacy datasource editor) to something larger than 32 characters, Superset should accept the change and confirm the row was changed in the database.

### ADDITIONAL INFORMATION
- [X] Has associated issue:
  * https://github.com/apache/superset/issues/13572
  * https://github.com/apache/superset/issues/13690
- [ ] Required feature flags:
- [ ] Changes UI
- [X] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [X] Migration is atomic, supports rollback & is backwards-compatible
  - [X] Confirm DB migration upgrade and downgrade tested
  - [X] Runtime estimates and downtime expectations provided: downtime is minimal, takes a second to execute the script.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
