### PR TITLE
Updating the plugin-chart-table version

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -95,7 +95,7 @@
     "@superset-ui/legacy-preset-chart-nvd3": "0.17.84-cccs.1",
     "@superset-ui/plugin-chart-echarts": "0.17.84-cccs.3",
     "@superset-ui/plugin-chart-pivot-table": "0.17.84-cccs.1",
-    "@superset-ui/plugin-chart-table": "0.17.84-cccs.2",
+    "@superset-ui/plugin-chart-table": "0.17.84-cccs.3",
     "@superset-ui/plugin-chart-word-cloud": "0.17.84-cccs.1",
     "@superset-ui/preset-chart-xy": "0.17.84-cccs.1",
     "@vx/responsive": "^0.0.195",


### PR DESCRIPTION
Pulling the newer version of plugin-chart-table which is cccs.3