### PR TITLE
Feature/cldn 1229

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -70,7 +70,7 @@
     "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",
-    "@superset-ui/chart-controls": "0.18.19-cccs.0",
+    "@superset-ui/chart-controls": "0.18.19-cccs.1",
     "@superset-ui/core": "0.18.19-cccs.0",
     "@superset-ui/legacy-plugin-chart-calendar": "0.18.19-cccs.0",
     "@superset-ui/legacy-plugin-chart-chord": "0.18.19-cccs.0",

--- a/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
@@ -59,13 +59,13 @@ describe('SelectControl', () => {
       expect(wrapper.find(SelectComponent)).toExist();
     });
 
-    it('renders with DeprecatedSelect when DeprecatedSelectFlag prop set to true', () => {
+    it('renders with DeprecatedSelect when DeprecatedSelectFlag=true', () => {
       wrapper.setProps({ deprecatedSelectFlag: true });
       expect(wrapper.find(SelectComponent)).not.toExist();
       expect(wrapper.find(DeprecatedSelect)).toExist();
     });
 
-    it('renders with Select when DeprecatedSelectFlag prop set to false', () => {
+    it('renders with Select when DeprecatedSelectFlag=false', () => {
       wrapper.setProps({ deprecatedSelectFlag: false });
       expect(wrapper.find(SelectComponent)).toExist();
       expect(wrapper.find(DeprecatedSelect)).not.toExist();

--- a/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
@@ -23,6 +23,7 @@ import { shallow } from 'enzyme';
 import { Select as SelectComponent } from 'src/components';
 import { Select as DeprecatedSelect } from 'src/components/Select/DeprecatedSelect';
 import SelectControl from 'src/explore/components/controls/SelectControl';
+import ControlHeader from 'src/explore/components/ControlHeader';
 import { styledMount as mount } from 'spec/helpers/theming';
 
 const defaultProps = {
@@ -59,16 +60,18 @@ describe('SelectControl', () => {
       expect(wrapper.find(SelectComponent)).toExist();
     });
 
-    it('renders with DeprecatedSelect when deprecatedSelectFlag=true', () => {
+    it('renders with DeprecatedSelect & ControlHeader when deprecatedSelectFlag=true', () => {
       wrapper.setProps({ deprecatedSelectFlag: true });
       expect(wrapper.find(SelectComponent)).not.toExist();
       expect(wrapper.find(DeprecatedSelect)).toExist();
+      expect(wrapper.find(ControlHeader)).toExist();
     });
 
     it('renders with Select when deprecatedSelectFlag=false', () => {
       wrapper.setProps({ deprecatedSelectFlag: false });
       expect(wrapper.find(SelectComponent)).toExist();
       expect(wrapper.find(DeprecatedSelect)).not.toExist();
+      expect(wrapper.find(ControlHeader)).not.toExist();
     });
 
     it('renders as mode multiple', () => {

--- a/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
@@ -21,6 +21,7 @@ import React from 'react';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import { Select as SelectComponent } from 'src/components';
+import { Select as DeprecatedSelect } from 'src/components/Select/DeprecatedSelect';
 import SelectControl from 'src/explore/components/controls/SelectControl';
 import { styledMount as mount } from 'spec/helpers/theming';
 
@@ -56,6 +57,18 @@ describe('SelectControl', () => {
   describe('render', () => {
     it('renders with Select by default', () => {
       expect(wrapper.find(SelectComponent)).toExist();
+    });
+
+    it('renders with DeprecatedSelect when DeprecatedSelectFlag prop set to true', () => {
+      wrapper.setProps({ deprecatedSelectFlag: true });
+      expect(wrapper.find(SelectComponent)).not.toExist();
+      expect(wrapper.find(DeprecatedSelect)).toExist();
+    });
+
+    it('renders with Select when DeprecatedSelectFlag prop set to false', () => {
+      wrapper.setProps({ deprecatedSelectFlag: false });
+      expect(wrapper.find(SelectComponent)).toExist();
+      expect(wrapper.find(DeprecatedSelect)).not.toExist();
     });
 
     it('renders as mode multiple', () => {

--- a/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
+++ b/superset-frontend/spec/javascripts/explore/components/SelectControl_spec.jsx
@@ -59,13 +59,13 @@ describe('SelectControl', () => {
       expect(wrapper.find(SelectComponent)).toExist();
     });
 
-    it('renders with DeprecatedSelect when DeprecatedSelectFlag=true', () => {
+    it('renders with DeprecatedSelect when deprecatedSelectFlag=true', () => {
       wrapper.setProps({ deprecatedSelectFlag: true });
       expect(wrapper.find(SelectComponent)).not.toExist();
       expect(wrapper.find(DeprecatedSelect)).toExist();
     });
 
-    it('renders with Select when DeprecatedSelectFlag=false', () => {
+    it('renders with Select when deprecatedSelectFlag=false', () => {
       wrapper.setProps({ deprecatedSelectFlag: false });
       expect(wrapper.find(SelectComponent)).toExist();
       expect(wrapper.find(DeprecatedSelect)).not.toExist();

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -129,6 +129,18 @@ export default class SelectControl extends React.PureComponent {
       onChangeVal = values;
     }
 
+    if (Array.isArray(val)) {
+      let values;
+      if (val.filter(v => v.value === 'Select all').length > 0) {
+        values = this.props.options
+          .filter(v => v.label !== 'Select all')
+          .map(v => v?.[valueKey] || v);
+      } else {
+        values = val.map(v => v?.[valueKey] || v);
+      }
+      onChangeVal = values;
+    }
+
     if (typeof val === 'object' && val?.[valueKey]) {
       onChangeVal = val[valueKey];
     }

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -52,6 +52,7 @@ const propTypes = {
   showHeader: PropTypes.bool,
   optionRenderer: PropTypes.func,
   valueRenderer: PropTypes.func,
+  deprecatedSelectFlag: PropTypes.bool,
   valueKey: PropTypes.string,
   options: PropTypes.array,
   placeholder: PropTypes.string,
@@ -88,6 +89,7 @@ const defaultProps = {
   allowAll: false,
   onChange: () => {},
   onFocus: () => {},
+  deprecatedSelectFlag: false,
   showHeader: true,
   valueKey: 'value',
   promptTextCreator: label => `Create Option ${label}`,
@@ -363,7 +365,7 @@ export default class SelectControl extends React.PureComponent {
           }
         `}
       >
-        {name === 'groupby' ? (
+        {this.props.deprecatedSelectFlag === true ? (
           <>
             <ControlHeader {...headerProps} />
             <DeprecatedSelect {...deprecatedProps} />

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -133,7 +133,7 @@ export default class SelectControl extends React.PureComponent {
       let values;
       if (val.filter(v => v.value === 'Select all').length > 0) {
         values = this.props.options
-          .filter(v => v.label !== 'Select all')
+          .filter(v => v.value !== 'Select all')
           .map(v => v?.[valueKey] || v);
       } else {
         values = val.map(v => v?.[valueKey] || v);

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -293,6 +293,16 @@ export default class SelectControl extends React.PureComponent {
       value: getValue(),
     };
 
+    const assistiveTextContents = inputArray => {
+      if (inputArray !== null) {
+        if (inputArray.length === 0) {
+          return '';
+        }
+        return `${inputArray.length} option(s)`;
+      }
+      return '';
+    };
+
     const deprecatedProps = {
       autoFocus,
       'aria-label': label,
@@ -315,7 +325,7 @@ export default class SelectControl extends React.PureComponent {
       value: getValue(),
       options: this.state.options,
       placeholder,
-      assistiveText: '',
+      assistiveText: assistiveTextContents(value),
       promptTextCreator,
       selectRef: this.getSelectRef,
       valueKey,

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 import { css, t } from '@superset-ui/core';
 import { Select } from 'src/components';
 import { SELECT_ALL_STRING } from 'src/components/Select/Select';
+import { Select as DeprecatedSelect } from 'src/components/Select/DeprecatedSelect';
 import ControlHeader from 'src/explore/components/ControlHeader';
 
 const propTypes = {
@@ -50,10 +51,16 @@ const propTypes = {
   ]),
   showHeader: PropTypes.bool,
   optionRenderer: PropTypes.func,
+  valueRenderer: PropTypes.func,
   valueKey: PropTypes.string,
   options: PropTypes.array,
   placeholder: PropTypes.string,
   filterOption: PropTypes.func,
+  promptTextCreator: PropTypes.func,
+  menuPortalTarget: PropTypes.element,
+  menuPosition: PropTypes.string,
+  menuPlacement: PropTypes.string,
+  forceOverflow: PropTypes.bool,
 
   // ControlHeader props
   label: PropTypes.string,
@@ -83,6 +90,7 @@ const defaultProps = {
   onFocus: () => {},
   showHeader: true,
   valueKey: 'value',
+  promptTextCreator: label => `Create Option ${label}`,
 };
 
 export default class SelectControl extends React.PureComponent {
@@ -210,8 +218,15 @@ export default class SelectControl extends React.PureComponent {
       placeholder,
       onFocus,
       optionRenderer,
+      promptTextCreator,
+      valueRenderer,
       showHeader,
       value,
+      valueKey,
+      forceOverflow,
+      menuPortalTarget,
+      menuPosition,
+      menuPlacement,
       // ControlHeader props
       description,
       renderTrigger,
@@ -278,6 +293,35 @@ export default class SelectControl extends React.PureComponent {
       value: getValue(),
     };
 
+    const deprecatedProps = {
+      autoFocus,
+      'aria-label': label,
+      clearable,
+      disabled,
+      filterOption,
+      ignoreAccents: false,
+      isLoading,
+      isMulti: this.props.isMulti || this.props.multi,
+      labelKey: 'label',
+      menuPlacement,
+      forceOverflow,
+      menuPortalTarget,
+      menuPosition,
+      name: `select-${name}`,
+      noResultsText: 'No results found',
+      onChange: this.onChange,
+      onFocus,
+      optionRenderer,
+      value: getValue(),
+      options: this.state.options,
+      placeholder,
+      assistiveText: '',
+      promptTextCreator,
+      selectRef: this.getSelectRef,
+      valueKey,
+      valueRenderer,
+    };
+
     return (
       <div
         css={theme => css`
@@ -292,7 +336,14 @@ export default class SelectControl extends React.PureComponent {
           }
         `}
       >
-        <Select {...selectProps} />
+        {name === 'groupby' ? (
+          <>
+            <ControlHeader {...headerProps} />
+            <DeprecatedSelect {...deprecatedProps} />
+          </>
+        ) : (
+          <Select {...selectProps} />
+        )}
       </div>
     );
   }

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -100,6 +100,7 @@ export default class SelectControl extends React.PureComponent {
       options: this.getOptions(props),
     };
     this.onChange = this.onChange.bind(this);
+    this.onChangeDeprecated = this.onChangeDeprecated.bind(this);
     this.handleFilterOptions = this.handleFilterOptions.bind(this);
   }
 
@@ -128,6 +129,20 @@ export default class SelectControl extends React.PureComponent {
         : val.map(v => v?.[valueKey] || v);
       onChangeVal = values;
     }
+
+    if (typeof val === 'object' && val?.[valueKey]) {
+      onChangeVal = val[valueKey];
+    }
+
+    this.props.onChange(onChangeVal, []);
+  }
+
+  // Beware: This is acting like an on-click instead of an on-change
+  // (firing every time user chooses vs firing only if a new option is chosen).
+  onChangeDeprecated(val) {
+    // will eventually call `exploreReducer`: SET_FIELD_VALUE
+    const { valueKey } = this.props;
+    let onChangeVal = val;
 
     if (Array.isArray(val)) {
       let values;
@@ -305,16 +320,6 @@ export default class SelectControl extends React.PureComponent {
       value: getValue(),
     };
 
-    const assistiveTextContents = inputArray => {
-      if (inputArray !== null) {
-        if (inputArray.length === 0) {
-          return '';
-        }
-        return `${inputArray.length} option(s)`;
-      }
-      return '';
-    };
-
     const deprecatedProps = {
       autoFocus,
       'aria-label': label,
@@ -331,13 +336,13 @@ export default class SelectControl extends React.PureComponent {
       menuPosition,
       name: `select-${name}`,
       noResultsText: 'No results found',
-      onChange: this.onChange,
+      onChange: this.onChangeDeprecated,
       onFocus,
       optionRenderer,
       value: getValue(),
       options: this.state.options,
       placeholder,
-      assistiveText: assistiveTextContents(value),
+      assistiveText: '',
       promptTextCreator,
       selectRef: this.getSelectRef,
       valueKey,

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -125,12 +125,14 @@ const groupByControl = {
   includeTime: false,
   description: t('One or many controls to group by'),
   optionRenderer: c => <StyledColumnOption column={c} showType />,
+  valueRenderer: c => <StyledColumnOption column={c} />,
   valueKey: 'column_name',
   filterOption: ({ data: opt }, text) =>
     (opt.column_name &&
       opt.column_name.toLowerCase().indexOf(text.toLowerCase()) >= 0) ||
     (opt.verbose_name &&
       opt.verbose_name.toLowerCase().indexOf(text.toLowerCase()) >= 0),
+  promptTextCreator: label => label,
   mapStateToProps: (state, control) => {
     const newState = {};
     if (state.datasource) {

--- a/superset-frontend/src/explore/controls.jsx
+++ b/superset-frontend/src/explore/controls.jsx
@@ -126,6 +126,7 @@ const groupByControl = {
   description: t('One or many controls to group by'),
   optionRenderer: c => <StyledColumnOption column={c} showType />,
   valueRenderer: c => <StyledColumnOption column={c} />,
+  deprecatedSelectFlag: true,
   valueKey: 'column_name',
   filterOption: ({ data: opt }, text) =>
     (opt.column_name &&


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This branch is the implementation of the feature outlined in CLDN-1229 (allows users to reorder their selected items in the multi-select component). 

Alongside the reorder feature being added back in, two new unit tests were added to make sure that the reorder functionality is only used within the multi-select component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Traverse to the superset-frontend folder and run the following command:

- `npm test ./spec/javascripts/explore/components/SelectControl_spec.jsx` 

This command will run the unit tests for the SelectControl component (the component that was modified for this feature)
**NOTE:** The 'returns all options on select all' unit test in this file will fail, it fails on the main cccs-1.4 branch as well

You can also manually verify the UI changes if you start the back-end and front-end servers and traverse to a datasource such as "channel_members". Select "AGGREGATE" under 'Query Mode' and the "Group By" filter field should allow you to reorder the selected filters (if there are two or more selected filters). Next, select "RAW RECORDS" under 'Query Mode' and the "Columns" filter field should also allow you to reorder the selected filters (if there are two or more selected filters). No other filter fields should allow for reordering.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
