### PR TITLE
Feature/cldn 1142

### DIFF
--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-application-links/src/ApplicationLinks.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-application-links/src/ApplicationLinks.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { ApplicationsProps } from './types';
+import styles from './styles';
 
 export default function ApplicationLinks(props: ApplicationsProps) {
   const { application, appVal, appType } = props;
@@ -14,40 +15,16 @@ export default function ApplicationLinks(props: ApplicationsProps) {
     if (appType === 'USER_ID') {
       url = `https://alfred-tst.u.chimera.azure.cyber.gc.ca/?expression=MATCH%20(email:EMAIL_ADDRESS)%20WHERE%20email.value%20in%20[%22${appVal}%22]%20return%20email.value,%20email.maliciousness,%20email.uri`;
       infoType = 'user id';
-      //callback_url = 'user_id';
     } else {
       url = `https://alfred-tst.u.chimera.azure.cyber.gc.ca/?expression=MATCH%20(ip%3AIP_ADDRESS)%20WHERE%20ip.value%20IN%20%5B%22${appVal}%22%5D%20RETURN%20ip.value%2C%20ip.maliciousness%2C%20ip.creation_date%2C%20ip.created_by%2C%20ip.uri%2C%20ip.report_uri`;
       infoType = 'IP';
-      //callback_url = 'ip_string';
     }
   }
-  // TODO: this can be fixed after CLDN-929
-  // useEffect(() => {
-  //   fetch(
-  //     // eslint-disable-next-line no-restricted-globals
-  //     `http://${location.host}/api/v1/proxy/alfred/${callback_url}/${appVal}`,
-  //   )
-  //     .then(res => res.json())
-  //     .then(response => {
-  //       if (response !== null && response.payload !== undefined) {
-  //         setAlfredCount(response.payload.data?.length);
-  //       } else {
-  //         setAlfredCount(0);
-  //       }
-  //     })
-  //     .catch(e => {
-  //       // eslint-disable-next-line no-console
-  //       console.log(e);
-  //       setAlfredCount(0);
-  // This will be caught by supersets default error handling that wraps and will display this message the the user 
-  //       throw new Error("Failed to fetch results from Alfred");
-  //     });
-  // }, [appVal, callback_url]);
 
   return (
     <div>
-      <div>
-        <a href={url} target="_blank" rel="noreferrer">
+      <div style={styles.InlineBlock}>
+        <a href={url} target="_blank" rel="noreferrer" style={styles.InlineImg}>
           <img
             height="17"
             width="30"
@@ -56,7 +33,7 @@ export default function ApplicationLinks(props: ApplicationsProps) {
           />
         </a>
         {alfredCount > 0 ? (
-          <p>
+          <p style={styles.InlineText}>
             Alfred has seen this {infoType} {alfredCount} time(s).  Search the{' '}
             <a href={url} target="_blank" rel="noreferrer">
               Alfred
@@ -64,7 +41,7 @@ export default function ApplicationLinks(props: ApplicationsProps) {
             knowledge base.
           </p>
         ) : (
-          <p>
+          <p style={styles.InlineText}>
             Alfred has not seen this {infoType}.  Search the{' '}
             <a href={url} target="_blank" rel="noreferrer">
               Alfred

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-application-links/src/styles.js
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-application-links/src/styles.js
@@ -1,0 +1,22 @@
+const InlineBlock = {
+  display: 'inline-block',
+};
+
+const InlineImg = {
+  display: 'inline-block',
+  transform: 'translateY(-10%)',
+  '-ms-transform': 'translateY(-10%)',
+};
+
+const InlineText = {
+  display: 'inline-block',
+  'text-align': 'center',
+};
+
+const styles = {
+  InlineBlock,
+  InlineImg,
+  InlineText,
+};
+
+export default styles;

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-dns/src/AtAGlanceDns.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-dns/src/AtAGlanceDns.tsx
@@ -1,6 +1,5 @@
 import { QueryFormData } from '@superset-ui/core';
 import React, { useState } from 'react';
-import { RiGlobalFill } from 'react-icons/ri';
 
 const DEFAULT_IP_STRING = '1.1.1.1';
 const IP_STRING = 'ip_string';
@@ -55,16 +54,15 @@ const AtAGlanceCoreDns = (initialFormData: QueryFormData) => {
   return (
     <>
       <div>
-        <RiGlobalFill />
-        <span>Associated Hostnames:</span>
-      </div>
-      <div>
-        <table>
-          {getHostnames(displayData).map((hostname: string) => (
-            <tr>
-              <td>{hostname}</td>
-            </tr>
-          ))}
+        <table className="table table-striped table-condensed">
+          <tbody>
+            {getHostnames(displayData).map((hostname: string) => (
+              <tr>
+                <td>{hostname}</td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot />
         </table>
       </div>
     </>

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-dns/src/plugin/controlPanel.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-dns/src/plugin/controlPanel.ts
@@ -107,7 +107,6 @@ const config: ControlPanelConfig = {
       label: t('Query'),
       expanded: true,
       controlSetRows: [
-        ['metrics'],
         ['adhoc_filters'],
         ['row_limit', null],
         [

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-ip/src/AtAGlanceIP.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-ip/src/AtAGlanceIP.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import { RiGlobalFill } from 'react-icons/ri';
 import { QueryFormData } from '@superset-ui/core';
-// import styles from './styles';
+import styles from './styles';
 
 const DEFAULT_IP_STRING = '1.1.1.1';
 const IP_STRING = 'ip_string';
@@ -60,35 +59,41 @@ const AtAGlanceCoreIp = (initialFormData: QueryFormData) => {
   return (
     <>
       <div>
-        <RiGlobalFill />
-        <span>At a Glance</span>
-      </div>
-      <div>
-        <table>
-          <tr>
-            <td> IP: {ipString}</td>
-          </tr>
-          <tr>
-            <td>ASN: {displayData.asn}</td>
-          </tr>
-          <tr>
-            <td>CARRIER: {displayData.carrier}</td>
-          </tr>
-          <tr>
-            <td>CONNECTION TYPE: {displayData.connectionType}</td>
-          </tr>
-          <tr>
-            <td>ORGANIZATION: {displayData.organization}</td>
-          </tr>
-          <tr>
-            <td>CITY: {displayData.city}</td>
-          </tr>
-          <tr>
-            <td>COUNTRY: {displayData.country}</td>
-          </tr>
-          <tr>
-            <td>DECIMAL: {decimalDisplayData}</td>
-          </tr>
+        <table className="table table-striped table-condensed">
+          <tbody>
+            <tr>
+              <td style={styles.MiddleLine}>IP</td>
+              <td>{ipString}</td>
+            </tr>
+            <tr>
+              <td style={styles.MiddleLine}>ASN</td>
+              <td>{displayData.asn}</td>
+            </tr>
+            <tr>
+              <td style={styles.MiddleLine}>Carrier</td>
+              <td>{displayData.carrier}</td>
+            </tr>
+            <tr>
+              <td style={styles.MiddleLine}>Connection Type</td>
+              <td>{displayData.connectionType}</td>
+            </tr>
+            <tr>
+              <td style={styles.MiddleLine}>Organization</td>
+              <td>{displayData.organization}</td>
+            </tr>
+            <tr>
+              <td style={styles.MiddleLine}>City</td>
+              <td>{displayData.city}</td>
+            </tr>
+            <tr>
+              <td style={styles.MiddleLine}>Country</td>
+              <td>{displayData.country}</td>
+            </tr>
+            <tr>
+              <td style={styles.MiddleLine}>Decimal</td>
+              <td>{decimalDisplayData}</td>
+            </tr>
+          </tbody>
         </table>
       </div>
     </>

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-ip/src/styles.js
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-ip/src/styles.js
@@ -47,6 +47,14 @@ const HostnameTitle = {
   'padding-bottom': '1px',
 };
 
+const MiddleLine = {
+  borderRight: '1px solid #e0e0e0',
+};
+
+const BottomLine = {
+  borderBottom: '1px solid #e0e0e0',
+};
+
 const styles = {
   Datum,
   DatumLink,
@@ -55,6 +63,8 @@ const styles = {
   DropListHeader,
   RowBullet,
   HostnameTitle,
+  MiddleLine,
+  BottomLine,
 };
 
 export default styles;

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id-sas/src/AtAGlanceUserIdSas.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id-sas/src/AtAGlanceUserIdSas.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { RiGlobalFill } from 'react-icons/ri';
 import { QueryFormData } from '@superset-ui/core';
-import Collapse from 'src/components/Collapse';
 
 // Main Component
 const AtAGlanceUserIdSasCore = (initialFormData: QueryFormData) => {
@@ -28,34 +26,15 @@ const AtAGlanceUserIdSasCore = (initialFormData: QueryFormData) => {
   return (
     <>
       <div>
-        <RiGlobalFill />
-        <span>At a Glance</span>
-      </div>
-      <div>
-        <table>
-          <tr>
-            <td>User Email: {userIDString}</td>
-          </tr>
-        </table>
-      </div>
-      <div>
-        <table>
-          <tr>
-            <Collapse bordered expandIconPosition="left" ghost>
-              <Collapse.Panel
-                header={<span className="header">Count: {data.length}</span>}
-                key="count"
-              >
-                <ul>
-                  {data.map((a: { operation: string; count: number }) => (
-                    <li>
-                      {a.operation} : {a.count}
-                    </li>
-                  ))}
-                </ul>
-              </Collapse.Panel>
-            </Collapse>
-          </tr>
+        <table className="table table-striped table-condensed">
+          <tbody>
+            {data.map((a: { operation: string; count: number }) => (
+              <tr>
+                <td>{a.operation}</td>
+                <td>{a.count}</td>
+              </tr>
+            ))}
+          </tbody>
         </table>
       </div>
     </>

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { RiGlobalFill } from 'react-icons/ri';
 import { QueryFormData } from '@superset-ui/core';
 import Collapse from 'src/components/Collapse';
+import styles from './styles';
 
 type DataManager = {
   data: any[];
@@ -13,29 +14,32 @@ type DataManager = {
 type AtAGlanceUserIDProps = QueryFormData & {
   ipDashboardId: string;
   ipDashboardFilterId: string;
-  ipDashBoardBaseUrl: string; 
+  ipDashBoardBaseUrl: string;
 };
 
-const generateClientIpLinksList = (ipList: any, ipDashBoardBaseUrl: string, ipDashboardId: string, ipDashboardFilterId: string) => {
-  return(
-    <ul>
-      {ipList.map((a: { client_ip: string }) => (
-        <li>
-          <a
-            href={
-              `${ipDashBoardBaseUrl}/superset/dashboard/${ipDashboardId}/?native_filters=%28NATIVE_FILTER-${ipDashboardFilterId}%3A%28__cache%3A%28label%3A'${a.client_ip}'` +
-              `%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${a.client_ip}'%29%29%2CextraFormData%3A%28filters%3A%21%28%28col%3Aip_string%2Cop%3AIN%2Cval%3A%21%28'${a.client_ip}'` +
-              `%29%29%29%29%2CfilterState%3A%28label%3A'${a.client_ip}'%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${a.client_ip}'%29%29%2Cid%3ANATIVE_FILTER-${ipDashboardFilterId}` +
-              `%2CownState%3A%28%29%29%29`}
-          >
-            {a.client_ip}
-          </a>
-        </li>
-      ))}
-    </ul>
-  )
-}
-
+const generateClientIpLinksList = (
+  ipList: any,
+  ipDashBoardBaseUrl: string,
+  ipDashboardId: string,
+  ipDashboardFilterId: string,
+) => (
+  <ul>
+    {ipList.map((a: { client_ip: string }) => (
+      <li>
+        <a
+          href={
+            `${ipDashBoardBaseUrl}/superset/dashboard/${ipDashboardId}/?native_filters=%28NATIVE_FILTER-${ipDashboardFilterId}%3A%28__cache%3A%28label%3A'${a.client_ip}'` +
+            `%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${a.client_ip}'%29%29%2CextraFormData%3A%28filters%3A%21%28%28col%3Aip_string%2Cop%3AIN%2Cval%3A%21%28'${a.client_ip}'` +
+            `%29%29%29%29%2CfilterState%3A%28label%3A'${a.client_ip}'%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${a.client_ip}'%29%29%2Cid%3ANATIVE_FILTER-${ipDashboardFilterId}` +
+            `%2CownState%3A%28%29%29%29`
+          }
+        >
+          {a.client_ip}
+        </a>
+      </li>
+    ))}
+  </ul>
+);
 
 /**
  *   getPayloadField:
@@ -67,8 +71,10 @@ const getPayloadField = (field: string, payload: any) => {
     // eslint-disable-next-line no-console
     console.log(e);
     value = 'Something went wrong';
-    // This will be caught by supersets default error handling that wraps and will display this message the the user 
-    throw new Error("Error fetching values from dataset. This may be caused by having this viz on the incorrect dataset.")
+    // This will be caught by supersets default error handling that wraps and will display this message the the user
+    throw new Error(
+      'Error fetching values from dataset. This may be caused by having this viz on the incorrect dataset.',
+    );
   }
 
   return value;
@@ -76,9 +82,8 @@ const getPayloadField = (field: string, payload: any) => {
 
 // Main Component
 function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
-
   const [userIDString, setUserIDString] = useState('user@domain.invalid,');
-  
+
   let canadianIpsList: any[] = [];
   let nonCanadianIpsList: any[] = [];
   let unsuccessfulCanadianIpsList: any[] = [];
@@ -156,7 +161,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
   }
 
   return (
-    <>
+    <div style={styles.AtAGlance}>
       <div>
         <RiGlobalFill />
         <span>At a Glance</span>
@@ -176,7 +181,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
           </tr>
         </table>
       </div>
-      <div>
+      <div style={styles.AtAGlanceLists}>
         <table>
           <tr>
             <Collapse bordered expandIconPosition="left" ghost>
@@ -191,11 +196,17 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                   </span>
                 }
                 key="1"
+                style={styles.HostList}
               >
                 {aadDataManager.isLoading && !aadDataManager.isInit ? (
                   <></>
                 ) : (
-                  generateClientIpLinksList(canadianIpsList, props.ipDashBoardBaseUrl, props.ipDashboardId, props.ipDashboardFilterId)
+                  generateClientIpLinksList(
+                    canadianIpsList,
+                    props.ipDashBoardBaseUrl,
+                    props.ipDashboardId,
+                    props.ipDashboardFilterId,
+                  )
                 )}
               </Collapse.Panel>
               <Collapse.Panel
@@ -209,11 +220,17 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                   </span>
                 }
                 key="2"
+                style={styles.HostList}
               >
                 {aadDataManager.isLoading && !aadDataManager.isInit ? (
                   <></>
                 ) : (
-                  generateClientIpLinksList(nonCanadianIpsList, props.ipDashBoardBaseUrl, props.ipDashboardId, props.ipDashboardFilterId)
+                  generateClientIpLinksList(
+                    nonCanadianIpsList,
+                    props.ipDashBoardBaseUrl,
+                    props.ipDashboardId,
+                    props.ipDashboardFilterId,
+                  )
                 )}
               </Collapse.Panel>
               <Collapse.Panel
@@ -227,11 +244,17 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                   </span>
                 }
                 key="3"
+                style={styles.HostList}
               >
                 {aadDataManager.isLoading && !aadDataManager.isInit ? (
                   <></>
                 ) : (
-                  generateClientIpLinksList(unsuccessfulCanadianIpsList, props.ipDashBoardBaseUrl, props.ipDashboardId, props.ipDashboardFilterId)
+                  generateClientIpLinksList(
+                    unsuccessfulCanadianIpsList,
+                    props.ipDashBoardBaseUrl,
+                    props.ipDashboardId,
+                    props.ipDashboardFilterId,
+                  )
                 )}
               </Collapse.Panel>
               <Collapse.Panel
@@ -245,18 +268,24 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                   </span>
                 }
                 key="4"
+                style={styles.HostList}
               >
                 {aadDataManager.isLoading && !aadDataManager.isInit ? (
                   <></>
                 ) : (
-                  generateClientIpLinksList(unsuccessfulNonCanadianIpsList, props.ipDashBoardBaseUrl, props.ipDashboardId, props.ipDashboardFilterId)
+                  generateClientIpLinksList(
+                    unsuccessfulNonCanadianIpsList,
+                    props.ipDashBoardBaseUrl,
+                    props.ipDashboardId,
+                    props.ipDashboardFilterId,
+                  )
                 )}
               </Collapse.Panel>
             </Collapse>
           </tr>
         </table>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { RiGlobalFill } from 'react-icons/ri';
 import { QueryFormData } from '@superset-ui/core';
 import Collapse from 'src/components/Collapse';
 import styles from './styles';
@@ -23,22 +22,29 @@ const generateClientIpLinksList = (
   ipDashboardId: string,
   ipDashboardFilterId: string,
 ) => (
-  <ul>
-    {ipList.map((a: { client_ip: string }) => (
-      <li>
-        <a
-          href={
-            `${ipDashBoardBaseUrl}/superset/dashboard/${ipDashboardId}/?native_filters=%28NATIVE_FILTER-${ipDashboardFilterId}%3A%28__cache%3A%28label%3A'${a.client_ip}'` +
-            `%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${a.client_ip}'%29%29%2CextraFormData%3A%28filters%3A%21%28%28col%3Aip_string%2Cop%3AIN%2Cval%3A%21%28'${a.client_ip}'` +
-            `%29%29%29%29%2CfilterState%3A%28label%3A'${a.client_ip}'%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${a.client_ip}'%29%29%2Cid%3ANATIVE_FILTER-${ipDashboardFilterId}` +
-            `%2CownState%3A%28%29%29%29`
-          }
-        >
-          {a.client_ip}
-        </a>
-      </li>
-    ))}
-  </ul>
+  <table
+    className="table table-striped table-condensed"
+    style={styles.AtAGlanceLists}
+  >
+    <tbody>
+      {ipList.map((a: { client_ip: string }) => (
+        <tr>
+          <td>
+            <a
+              href={
+                `${ipDashBoardBaseUrl}/superset/dashboard/${ipDashboardId}/?native_filters=%28NATIVE_FILTER-${ipDashboardFilterId}%3A%28__cache%3A%28label%3A'${a.client_ip}'` +
+                `%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${a.client_ip}'%29%29%2CextraFormData%3A%28filters%3A%21%28%28col%3Aip_string%2Cop%3AIN%2Cval%3A%21%28'${a.client_ip}'` +
+                `%29%29%29%29%2CfilterState%3A%28label%3A'${a.client_ip}'%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${a.client_ip}'%29%29%2Cid%3ANATIVE_FILTER-${ipDashboardFilterId}` +
+                `%2CownState%3A%28%29%29%29`
+              }
+            >
+              {a.client_ip}
+            </a>
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
 );
 
 /**
@@ -163,10 +169,6 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
   return (
     <div style={styles.AtAGlance}>
       <div>
-        <RiGlobalFill />
-        <span>At a Glance</span>
-      </div>
-      <div>
         <table>
           <tr>
             <td>User Email: {userIDString}</td>
@@ -181,7 +183,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
           </tr>
         </table>
       </div>
-      <div style={styles.AtAGlanceLists}>
+      <div>
         <table>
           <tr>
             <Collapse bordered expandIconPosition="left" ghost>

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/styles.js
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/styles.js
@@ -39,7 +39,7 @@ const SectionTitle = {
 };
 
 const UrlList = {
-  hight: '100%',
+  height: '100%',
   width: '100%',
   maxWidth: 360,
   overflow: 'auto',
@@ -54,17 +54,29 @@ const UrlListItem = {
 
 const HostList = {
   maxHeight: 200,
+  overflow: 'auto',
 };
 
 const RowBullet = {
   display: 'list-item',
   'list-style-type': 'disc',
-  'list-style-position': 'inside'
+  'list-style-position': 'inside',
 };
 
 const HostnameTitle = {
   'padding-left': '5px',
   'margin-bottom': '0',
+};
+
+const AtAGlance = {
+  maxHeight: '300px',
+  overflow: 'auto',
+};
+
+const AtAGlanceLists = {
+  maxHeight: '100%',
+  maxWidth: '100%',
+  overflow: 'auto',
 };
 
 const styles = {
@@ -78,6 +90,8 @@ const styles = {
   HostList,
   RowBullet,
   HostnameTitle,
+  AtAGlance,
+  AtAGlanceLists,
 };
 
 export default styles;


### PR DESCRIPTION
### SUMMARY
Previously long lists would break out of the container and the values
would be written all the way down the viewable area.  This change
will cause scrollbars to appear and overflow will be handled by the
browser.

- Added superset table styles to make AAG components look more like a
  superset component
- Added in some separating lines for IP AAG
- Aligned the icon with the text for application links
- Fixed up the control panel for AAG DNS so a metric is no longer
  required.  The use of count was making the query extra long.
- Other bits of clean up as well

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
