### PR TITLE
[CLDN-1313] Added step to properly handle metrics column data that wa…

### DIFF
--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/transformProps.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/transformProps.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Column, QueryMode, t, TimeseriesDataRecord } from '@superset-ui/core';
+import { Column, getMetricLabel, QueryMode, t, TimeseriesDataRecord } from '@superset-ui/core';
 import {
   CccsGridChartProps,
   CccsGridQueryFormData,
@@ -183,7 +183,9 @@ export default function transformProps(chartProps: CccsGridChartProps) {
     }
 
     if (formData.metrics) {
-      const metricsColumnDefs = formData.metrics.map((column: any) => {
+      const metricsColumnDefs = formData.metrics
+        .map(getMetricLabel)
+        .map((column: any) => {
         const columnHeader = columnVerboseNameMap[column]
           ? columnVerboseNameMap[column]
           : column;


### PR DESCRIPTION
### SUMMARY
This task is associated with the CLDN-1313 Task

On the custom viz Hogwarts Table, the metrics columns did not display and caused an error when queries were run on the explore view for datasets.
The reason was due to the plugin file transformProps.ts not correctly handling the format of the request payload sent to the backend. The metrics columns come in a different format than the groupby columns, but they were handled the same way leading to an error being displayed instead of the table. There is a helper function in superset-ui core that handles this so I imported it and added that step in so the column definition prop is properly passed to the component and it now displays properly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
In the explore view for a dataset, query with hogwarts table viz type and some metric column added (SUM, AVG, etc.)
Before: 
![image](https://user-images.githubusercontent.com/102618419/162236501-7ea55252-34c2-4042-8238-49225b13c429.png)
After:
![image](https://user-images.githubusercontent.com/102618419/162236890-50677e00-a6bb-47ae-ba0b-8571969d56c3.png)


### TESTING INSTRUCTIONS
In the explore view for a dataset, create an aggregate query on some columns that includes a "metrics" column. before this change this would cause an error to be displayed instead of the table, but now the table is displayed properly with the metrics column included.

### ADDITIONAL INFORMATION
- [X] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
