### PR TITLE
Feature/cldn 1300

### DIFF
--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
@@ -191,7 +191,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                 header={
                   <span className="header">
                     {' '}
-                    Number of Successful Canadian Login Attempts :{' '}
+                    Number of Successful Canadian Login Attempts:{' '}
                     {aadDataManager.isLoading
                       ? 'Loading'
                       : canadianIpsList.length}{' '}
@@ -215,7 +215,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                 header={
                   <span className="header">
                     {' '}
-                    Number of Successful non Canadian Login Attempts :{' '}
+                    Number of Successful non Canadian Login Attempts:{' '}
                     {aadDataManager.isLoading
                       ? 'Loading'
                       : nonCanadianIpsList.length}{' '}
@@ -239,7 +239,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                 header={
                   <span className="header">
                     {' '}
-                    Number of Unsuccessful Canadian Login Attempts :{' '}
+                    Number of Unsuccessful Canadian Login Attempts:{' '}
                     {aadDataManager.isLoading
                       ? 'Loading'
                       : unsuccessfulCanadianIpsList.length}{' '}
@@ -263,7 +263,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                 header={
                   <span className="header">
                     {' '}
-                    Number of Unsuccessful non Canadian Login Attempts :{' '}
+                    Number of Unsuccessful non Canadian Login Attempts:{' '}
                     {aadDataManager.isLoading
                       ? 'Loading'
                       : unsuccessfulNonCanadianIpsList.length}{' '}

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
@@ -187,7 +187,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
   return (
     <div style={styles.AtAGlance}>
       <div>
-        <table>
+        <table style={styles.Table}>
           <tr>
             <td>
               **Please note that the results in this chart are only for the
@@ -208,7 +208,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
         </table>
       </div>
       <div>
-        <table>
+        <table style={styles.Table}>
           <tr>
             <Collapse bordered expandIconPosition="left" ghost>
               <Collapse.Panel

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
@@ -20,7 +20,7 @@ const getIPList = (ip_list: any) => {
   const counter = {};
 
   ip_list.forEach(function (obj: any) {
-    const key = JSON.stringify(obj);
+    const key = JSON.stringify(obj.client_ip);
     counter[key] = (counter[key] || 0) + 1;
   });
 
@@ -38,23 +38,29 @@ const generateClientIpLinksList = (
     style={styles.AtAGlanceLists}
   >
     <tbody>
-      {ipList.map((a: { client_ip: string }) => (
-        <tr>
-          <td>
-            <a
-              href={
-                `${ipDashBoardBaseUrl}/superset/dashboard/${ipDashboardId}/?native_filters=%28NATIVE_FILTER-${ipDashboardFilterId}%3A%28__cache%3A%28label%3A'${a.client_ip}'` +
-                `%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${a.client_ip}'%29%29%2CextraFormData%3A%28filters%3A%21%28%28col%3Aip_string%2Cop%3AIN%2Cval%3A%21%28'${a.client_ip}'` +
-                `%29%29%29%29%2CfilterState%3A%28label%3A'${a.client_ip}'%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${a.client_ip}'%29%29%2Cid%3ANATIVE_FILTER-${ipDashboardFilterId}` +
-                `%2CownState%3A%28%29%29%29`
-              }
-            >
-              {a.client_ip}
-            </a>
-            (5)
-          </td>
-        </tr>
-      ))}
+      <tr>
+        <th scope="col">IP Address</th>
+        <th scope="col">Count</th>
+      </tr>
+      {Object.keys(ipList)
+        .map(user_ip => user_ip.replaceAll('"', ''))
+        .map(user_ip => (
+          <tr>
+            <td>
+              <a
+                href={
+                  `${ipDashBoardBaseUrl}/superset/dashboard/${ipDashboardId}/?native_filters=%28NATIVE_FILTER-${ipDashboardFilterId}%3A%28__cache%3A%28label%3A'${user_ip}'` +
+                  `%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${user_ip}'%29%29%2CextraFormData%3A%28filters%3A%21%28%28col%3Aip_string%2Cop%3AIN%2Cval%3A%21%28'${user_ip}'` +
+                  `%29%29%29%29%2CfilterState%3A%28label%3A'${user_ip}'%2CvalidateStatus%3A%21f%2Cvalue%3A%21%28'${user_ip}'%29%29%2Cid%3ANATIVE_FILTER-${ipDashboardFilterId}` +
+                  `%2CownState%3A%28%29%29%29`
+                }
+              >
+                {user_ip}
+              </a>
+            </td>
+            <td>&nbsp;{ipList[`"${user_ip}"`]}</td>
+          </tr>
+        ))}
     </tbody>
   </table>
 );
@@ -222,7 +228,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                   <></>
                 ) : (
                   generateClientIpLinksList(
-                    canadianIpsList,
+                    getIPList(canadianIpsList),
                     props.ipDashBoardBaseUrl,
                     props.ipDashboardId,
                     props.ipDashboardFilterId,
@@ -246,7 +252,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                   <></>
                 ) : (
                   generateClientIpLinksList(
-                    nonCanadianIpsList,
+                    getIPList(nonCanadianIpsList),
                     props.ipDashBoardBaseUrl,
                     props.ipDashboardId,
                     props.ipDashboardFilterId,
@@ -270,7 +276,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                   <></>
                 ) : (
                   generateClientIpLinksList(
-                    unsuccessfulCanadianIpsList,
+                    getIPList(unsuccessfulCanadianIpsList),
                     props.ipDashBoardBaseUrl,
                     props.ipDashboardId,
                     props.ipDashboardFilterId,
@@ -294,7 +300,7 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
                   <></>
                 ) : (
                   generateClientIpLinksList(
-                    unsuccessfulNonCanadianIpsList,
+                    getIPList(unsuccessfulNonCanadianIpsList),
                     props.ipDashBoardBaseUrl,
                     props.ipDashboardId,
                     props.ipDashboardFilterId,

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/AtAGlanceUserID.tsx
@@ -16,6 +16,17 @@ type AtAGlanceUserIDProps = QueryFormData & {
   ipDashBoardBaseUrl: string;
 };
 
+const getIPList = (ip_list: any) => {
+  const counter = {};
+
+  ip_list.forEach(function (obj: any) {
+    const key = JSON.stringify(obj);
+    counter[key] = (counter[key] || 0) + 1;
+  });
+
+  return counter;
+};
+
 const generateClientIpLinksList = (
   ipList: any,
   ipDashBoardBaseUrl: string,
@@ -40,6 +51,7 @@ const generateClientIpLinksList = (
             >
               {a.client_ip}
             </a>
+            (5)
           </td>
         </tr>
       ))}
@@ -170,6 +182,12 @@ function AtAGlanceUserIDCore(props: AtAGlanceUserIDProps) {
     <div style={styles.AtAGlance}>
       <div>
         <table>
+          <tr>
+            <td>
+              **Please note that the results in this chart are only for the
+              first User Email**
+            </td>
+          </tr>
           <tr>
             <td>User Email: {userIDString}</td>
           </tr>

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/styles.js
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/styles.js
@@ -57,11 +57,6 @@ const HostList = {
   overflow: 'auto',
 };
 
-// const StickyHeader = {
-//   position: sticky,
-//   top: 0,
-// };
-
 const RowBullet = {
   display: 'list-item',
   'list-style-type': 'disc',
@@ -98,7 +93,6 @@ const styles = {
   UrlList,
   UrlListItem,
   HostList,
-  // StickyHeader,
   RowBullet,
   HostnameTitle,
   AtAGlance,

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/styles.js
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-at-a-glance-user-id/src/styles.js
@@ -57,6 +57,11 @@ const HostList = {
   overflow: 'auto',
 };
 
+// const StickyHeader = {
+//   position: sticky,
+//   top: 0,
+// };
+
 const RowBullet = {
   display: 'list-item',
   'list-style-type': 'disc',
@@ -70,7 +75,12 @@ const HostnameTitle = {
 
 const AtAGlance = {
   maxHeight: '300px',
+  width: '100%',
   overflow: 'auto',
+};
+
+const Table = {
+  width: '75%',
 };
 
 const AtAGlanceLists = {
@@ -88,9 +98,11 @@ const styles = {
   UrlList,
   UrlListItem,
   HostList,
+  // StickyHeader,
   RowBullet,
   HostnameTitle,
   AtAGlance,
+  Table,
   AtAGlanceLists,
 };
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR encompasses the work outlined in the CLDN-1300 ticket.

- Expanded the width of the tables in the AtAGlanceUserID viz, so that the titles no longer wrap to a second line
- Improved the consistency of the colons and surrounding spaces in the AtAGlanceUserID viz
- The AtAGlanceUserID viz now groups IP's and includes a count (# of times this IP is present) in the table
- Added a message to the AtAGlanceUserID viz that says that only the results from the first entered user ID is shown

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
