### PR TITLE
[CLDN-1360] Metric names are now properly used in the table headers

### DIFF
--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/transformProps.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/transformProps.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Column, getMetricLabel, QueryMode, t, TimeseriesDataRecord } from '@superset-ui/core';
+import { Column, getMetricLabel, Metric, QueryMode, t, TimeseriesDataRecord } from '@superset-ui/core';
 import {
   CccsGridChartProps,
   CccsGridQueryFormData,
@@ -74,6 +74,7 @@ export default function transformProps(chartProps: CccsGridChartProps) {
   const { setDataMask = () => {} } = hooks;
 
   const columns = datasource?.columns as Column[];
+  const metrics = datasource?.metrics as Metric[];
 
   // Map of column types, key is column name, value is column type
   const columnTypeMap = new Map<string, string>();
@@ -94,6 +95,16 @@ export default function transformProps(chartProps: CccsGridChartProps) {
     columnMap[name] = column.verbose_name;
     return columnMap;
   }, columnVerboseNameMap);
+
+  // Map of verbose names, key is metric name, value is verbose name
+  const metricVerboseNameMap = new Map<string, string>();
+  metrics.reduce(function (metricMap, metric: Metric) {
+    // @ts-ignore
+    const name = metric['metric_name'];
+    // @ts-ignore
+    metricMap[name] = metric.verbose_name;
+    return metricMap;
+  }, metricVerboseNameMap);
 
   // Map of sorting columns, key is column name, value is a struct of sort direction (asc/desc) and sort index
   const sortingColumnMap = new Map<string, {}>();
@@ -185,13 +196,13 @@ export default function transformProps(chartProps: CccsGridChartProps) {
     if (formData.metrics) {
       const metricsColumnDefs = formData.metrics
         .map(getMetricLabel)
-        .map((column: any) => {
-        const columnHeader = columnVerboseNameMap[column]
-          ? columnVerboseNameMap[column]
-          : column;
+        .map((metric: any) => {
+        const metricHeader = metricVerboseNameMap[metric]
+          ? metricVerboseNameMap[metric]
+          : metric;
         return {
-          field: column,
-          headerName: columnHeader,
+          field: metric,
+          headerName: metricHeader,
           sortable: true,
         };
       });


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR encompasses the code changes that are needed to complete the CLDN-1360 ticket:

-Modifications to the HOGWARTS viz code, so that when a label is defined for a metric in a dataset, the label is now properly used as a column header

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a dataset with sqllab, and save it as a new dataset
2. Edit the dataset just created, and go to the Metrics tab, add a label to the metric 'count'
3. Explore the dataset, select the HOGWARTS viz, select the aggregate (default) tab, select a column in the Group By drop down options, select the saved metric defined at the previous step as Metrics and hit the RUN button
4. The HOGWARTS viz shows 2 columns and the second column header should now properly display the metric label added/modified in step 2

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
