### PR TITLE
[CLDN-1341] Modified the markdown component so that the inner column's handle's mouse target is larger

### DIFF
--- a/superset-frontend/src/dashboard/stylesheets/resizable.less
+++ b/superset-frontend/src/dashboard/stylesheets/resizable.less
@@ -92,12 +92,12 @@
 
 .dragdroppable-column .resizable-container-handle--right {
   /* override the default because the inner column's handle's mouse target is very small */
-  right: -10px !important;
+  right: 0 !important;
 }
 
 .dragdroppable-column .dragdroppable-column .resizable-container-handle--right {
   /* override the default because the inner column's handle's mouse target is very small */
-  right: 0px !important;
+  right: 0 !important;
 }
 
 .resizable-container-handle--bottom {


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR encompasses the code changes for CLDN-1341:

-Modification of the markdown component such that the re-sizable container handle is wider

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![Very Small Column Resize Selection Area](https://user-images.githubusercontent.com/96579982/165098165-8e5961d1-b1e4-4e90-9c77-f17c64127a4b.PNG)

After:
![After Fix - Resize Markdown Width](https://user-images.githubusercontent.com/96579982/165098207-dda64302-7b23-4f49-a4cd-7949a0776035.PNG)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
