### PR TITLE
Feature/cldn 1676

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_2921_22315d60
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.0_20220916135810_b4887
+FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-1676_20220920183611_b4915
 
 
 USER root

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_2921_22315d60
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-1676_20220920183611_b4915
+FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.0_20220916135810_b4887
 
 
 USER root

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/transformProps.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/transformProps.ts
@@ -171,6 +171,20 @@ export default function transformProps(chartProps: CccsGridChartProps) {
     JSON: 'jsonValueRenderer',
   };
 
+  const formatIpV4 = (v: any) => {
+    const converted = `${(v >> 24) & 0xff}.${(v >> 16) & 0xff}.${
+      (v >> 8) & 0xff
+    }.${v & 0xff}`;
+    return converted;
+  };
+
+  const advancedTypeValueFormatter = (params: any) => {
+    if (params.colDef.cellRenderer === 'ipv4ValueRenderer') {
+      return formatIpV4(params.value.toString());
+    }
+    return params.value.toString();
+  };
+
   const percentMetricValueFormatter = function (params: ValueFormatterParams) {
     return getNumberFormatter(NumberFormats.PERCENT_3_POINT).format(
       params.value,
@@ -210,6 +224,7 @@ export default function transformProps(chartProps: CccsGridChartProps) {
         sort: sortDirection,
         sortIndex,
         enableRowGroup,
+        getQuickFilterText: (params: any) => advancedTypeValueFormatter(params),
       };
     });
   } else {
@@ -234,6 +249,8 @@ export default function transformProps(chartProps: CccsGridChartProps) {
           cellRenderer,
           sortable: isSortable,
           enableRowGroup,
+          getQuickFilterText: (params: any) =>
+            advancedTypeValueFormatter(params),
         };
       });
       columnDefs = columnDefs.concat(groupByColumnDefs);


### PR DESCRIPTION
This PR incorporates the changes outlined in the [CLDN-1676](https://cccs.atlassian.net/browse/CLDN-1676) ticket:

**Major Changes Include:**

- Modified the Hogwarts Table Viz so that you can now search on the IPv4 version of a row entry instead of searching for its RAW (integer) value

**NOTE:** By changing this functionality, you can no longer search for the RAW (integer) value of an entry, you will now have to search up the IPv4 version of it