### PR TITLE
Fixed the right click to emit dashboard cross-filters

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_2921_22315d60
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.0_20220923113053_b4951
+FROM uchimera.azurecr.io/cccs/superset-base:fix_CLDN-1724_20221004112632_b5024
 
 
 USER root

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_2921_22315d60
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:fix_CLDN-1724_20221004112632_b5024
+FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.0_20220923113053_b4951
 
 
 USER root

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/controlPanel.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/controlPanel.tsx
@@ -390,7 +390,7 @@ const config: ControlPanelConfig = {
         [
           isFeatureEnabled(FeatureFlag.DASHBOARD_CROSS_FILTERS)
             ? {
-                name: 'table_filter',
+                name: 'emitFilter',
                 config: {
                   type: 'CheckboxControl',
                   label: t('Emit dashboard cross filters'),


### PR DESCRIPTION
This PR incorporates the changes outlines in the following ticket: [link](https://cccs.atlassian.net/browse/CLDN-1724)

**Major Changes Include:**
- Modification to the control panel of the AG Grid, as the name of the checkbox (for enabling dashboard cross-filters) did not match the name which we were expecting in the other parts of the front-end code