### PR TITLE
Update trino python client

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_2921_22315d60
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.0_20221005132212_b5040
+FROM uchimera.azurecr.io/cccs/superset-base:update_trino_python_client_20221014152540_b5127
 
 
 USER root

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_2921_22315d60
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:update_trino_python_client_20221014152540_b5127
+FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.0_20221005132212_b5040
 
 
 USER root

--- a/cccs-build/superset/requirements.txt
+++ b/cccs-build/superset/requirements.txt
@@ -5,7 +5,7 @@ authlib==0.15.4
 python-json-logger==2.0.2
 
 # Additional drivers for Superset (or SQLAlchemy) to use
-trino==0.316.0
+trino==0.318.0
 mysql-connector-python==8.0.26
 elasticsearch-dbapi==0.2.4
 cachetools~=5.0.0


### PR DESCRIPTION
This PR fixes an issue we were having with some of the datasets where when you tried to view them, they would give the error: `"TableClause" object has no attribute "dialect_options"`

Turns out this issue was easily resolved by changing which version of the Trino Python Client we use (version `0.316.0` -> `0.318.0`)