### PR TITLE
CLDN-1828 Fix minor issues with Adhoc Filters

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_2921_22315d60
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:CLDN-1828-Fix-minor-issues-with-adhoc-native-filters_20230103131042_b5908
+FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.0_20221014182839_b5135
 
 
 

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_2921_22315d60
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.0_20221014182839_b5135
+FROM uchimera.azurecr.io/cccs/superset-base:CLDN-1828-Fix-minor-issues-with-adhoc-native-filters_20230103131042_b5908
 
 
 

--- a/superset-frontend/src/filters/components/Adhoc/AdhocFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Adhoc/AdhocFilterPlugin.tsx
@@ -129,6 +129,7 @@ export default function PluginFilterAdhoc(props: PluginFilterAdhocProps) {
           const dataset = response.json?.result;
           // modify the response to fit structure expected by AdhocFilterControl
           dataset.type = dataset.datasource_type;
+          // setting filter_select to false will disable suggestions
           dataset.filter_select = false;
           setDatasetDetails(dataset);
         })

--- a/superset-frontend/src/filters/components/Adhoc/AdhocFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Adhoc/AdhocFilterPlugin.tsx
@@ -24,7 +24,6 @@ import {
   JsonObject,
   JsonResponse,
   smartDateDetailedFormatter,
-  styled,
   SupersetApiError,
   SupersetClient,
   t,

--- a/superset-frontend/src/filters/components/Adhoc/AdhocFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Adhoc/AdhocFilterPlugin.tsx
@@ -129,7 +129,7 @@ export default function PluginFilterAdhoc(props: PluginFilterAdhocProps) {
           const dataset = response.json?.result;
           // modify the response to fit structure expected by AdhocFilterControl
           dataset.type = dataset.datasource_type;
-          dataset.filter_select = true;
+          dataset.filter_select = false;
           setDatasetDetails(dataset);
         })
         .catch((response: SupersetApiError) => {

--- a/superset-frontend/src/filters/components/Adhoc/AdhocFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Adhoc/AdhocFilterPlugin.tsx
@@ -24,6 +24,7 @@ import {
   JsonObject,
   JsonResponse,
   smartDateDetailedFormatter,
+  styled,
   SupersetApiError,
   SupersetClient,
   t,
@@ -41,13 +42,9 @@ import { getClientErrorObject } from 'src/utils/getClientErrorObject';
 // eslint-disable-next-line import/no-unresolved
 import { useChangeEffect } from 'src/hooks/useChangeEffect';
 import { PluginFilterAdhocProps } from './types';
-import {
-  StyledFormItem,
-  FilterPluginStyle,
-  StatusMessage,
-  ControlContainer,
-} from '../common';
+import { StyledFormItem, FilterPluginStyle, StatusMessage } from '../common';
 import { getDataRecordFormatter, getAdhocExtraFormData } from '../../utils';
+import { AdhocControlContainer } from './styles';
 
 type DataMaskAction =
   | { type: 'ownState'; ownState: JsonObject }
@@ -94,6 +91,7 @@ export default function PluginFilterAdhoc(props: PluginFilterAdhocProps) {
     setFocusedFilter,
     unsetFocusedFilter,
     appSection,
+    inputRef,
   } = props;
   const { enableEmptyFilter, inverseSelection, defaultToFirstItem } = formData;
   const datasetId = useMemo(
@@ -231,10 +229,14 @@ export default function PluginFilterAdhoc(props: PluginFilterAdhocProps) {
         validateStatus={filterState.validateStatus}
         extra={formItemExtra}
       >
-        <ControlContainer
+        <AdhocControlContainer
+          tabIndex={-1}
+          ref={inputRef}
+          validateStatus={filterState.validateStatus}
+          onFocus={setFocusedFilter}
+          onBlur={unsetFocusedFilter}
           onMouseEnter={setFocusedFilter}
           onMouseLeave={unsetFocusedFilter}
-          validateStatus={filterState.validateStatus}
         >
           <AdhocFilterControl
             columns={columns || []}
@@ -247,7 +249,7 @@ export default function PluginFilterAdhoc(props: PluginFilterAdhocProps) {
             label={' '}
             value={filterState.filters || []}
           />
-        </ControlContainer>
+        </AdhocControlContainer>
       </StyledFormItem>
     </FilterPluginStyle>
   );

--- a/superset-frontend/src/filters/components/Adhoc/styles.tsx
+++ b/superset-frontend/src/filters/components/Adhoc/styles.tsx
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { styled } from '@superset-ui/core';
+
+export const AdhocControlContainer = styled.div<{
+  validateStatus?: 'error' | 'warning' | 'info';
+}>`
+    border: 1px solid transparent;
+
+    & div.ControlHeader,
+    & button{
+      visibility: hidden;
+      height: 0;
+      width 0;
+    }
+
+    &:hover{
+      transition-duration: ${({ theme }) => theme.transitionTiming}s;
+      transition-property: border-color, box-shadow;
+      transition-timing-function: ease-in-out;
+      border: ${({ theme, validateStatus }) =>
+        `1px solid ${
+          validateStatus
+            ? theme.colors[validateStatus]?.base
+            : theme.colors.primary.base
+        }`} !important;
+      border-radius: ${({ theme }) => theme.borderRadius}px;
+    }
+
+    &:focus{
+      transition-duration: ${({ theme }) => theme.transitionTiming}s;
+      transition-property: border-color, box-shadow;
+      transition-timing-function: ease-in-out;
+      border: ${({ theme, validateStatus }) =>
+        `1px solid ${
+          validateStatus
+            ? theme.colors[validateStatus]?.base
+            : theme.colors.primary.base
+        }`} !important;
+      border-radius: ${({ theme }) => theme.borderRadius}px;
+      box-shadow: 0 0 0 2px
+        ${({ validateStatus }) =>
+          validateStatus
+            ? 'rgba(224, 67, 85, 12%)'
+            : 'rgba(32, 167, 201, 0.2)'};
+    }
+  `;

--- a/superset-frontend/src/filters/components/Adhoc/types.ts
+++ b/superset-frontend/src/filters/components/Adhoc/types.ts
@@ -50,19 +50,6 @@ export interface PluginFilterSelectChartProps extends ChartProps {
   queriesData: ChartDataResponseResult[];
 }
 
-export type PluginFilterSelectProps = PluginFilterStylesProps & {
-  coltypeMap: Record<string, GenericDataType>;
-  data: DataRecord[];
-  behaviors: Behavior[];
-  appSection: AppSection;
-  formData: PluginFilterSelectQueryFormData;
-  filterState: FilterState;
-  isRefreshing: boolean;
-  showOverflow: boolean;
-  parentRef?: RefObject<any>;
-  inputRef?: RefObject<any>;
-} & PluginFilterHooks;
-
 export type PluginFilterAdhocProps = PluginFilterStylesProps & {
   coltypeMap: Record<string, GenericDataType>;
   data: DataRecord[];


### PR DESCRIPTION
…mpty header

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The following 2 issues were pointed out with the adhoc native filter plugin:
* There are suggested values for IPv4 advanced types, they are the raw values rather than the dot decimal values. The normal behaviour would be to not show suggested values.
* The chart filter tooltip that shows the current filter values for each filter has no effect when clicking on an adhoc filter. The function when a filter name (or its value) of the chart tooltip is clicked and the corresponding filter is highlighted in the filter list does not work for adhoc filters but works for others.

Suggestions are now disabled, and a new styles file was added that hides the awkward empty header space that was present int he adhoc filter component, and highlights the component when focused. The input ref was also correctly passed to the adhoc filter container so that it can be highlighted when it is focused via the charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
