### PR TITLE
fix: CLDN-1928-Adhoc Filter displays as not applied when empty

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_2921_22315d60
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:CLDN-1928-filter-incorrectly-displays-as-applied_20230203161428_b6147
+FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.0_20230117193544_b6002
 
 
 

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_2921_22315d60
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.0_20230117193544_b6002
+FROM uchimera.azurecr.io/cccs/superset-base:CLDN-1928-filter-incorrectly-displays-as-applied_20230203161428_b6147
 
 
 

--- a/superset-frontend/src/filters/components/Adhoc/AdhocFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Adhoc/AdhocFilterPlugin.tsx
@@ -58,7 +58,7 @@ type DataMaskAction =
       filterState: {
         label?: string;
         filters?: AdhocFilter[];
-        value: AdhocFilter[];
+        value?: AdhocFilter[];
       };
     };
 
@@ -184,13 +184,15 @@ export default function PluginFilterAdhoc(props: PluginFilterAdhocProps) {
         ),
         filterState: {
           ...filterState,
-          label: (adhoc_filters || [])
-            .map(f =>
-              f.sqlExpression ? String(f.sqlExpression) : labelString(f),
-            )
-            .join(', '),
-          value: adhoc_filters,
-          filters: adhoc_filters,
+          label: adhoc_filters?.length
+            ? (adhoc_filters || [])
+                .map(f =>
+                  f.sqlExpression ? String(f.sqlExpression) : labelString(f),
+                )
+                .join(', ')
+            : undefined,
+          value: adhoc_filters?.length ? adhoc_filters : undefined,
+          filters: adhoc_filters?.length ? adhoc_filters : undefined,
         },
       });
     },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
