### PR TITLE
fixed value formatter for quick search to handle null values

### DIFF
--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/transformProps.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/plugin/transformProps.ts
@@ -190,11 +190,14 @@ export default function transformProps(chartProps: CccsGridChartProps) {
     return converted;
   };
 
-  const advancedTypeValueFormatter = (params: any) => {
-    if (params.colDef.cellRenderer === 'ipv4ValueRenderer') {
+  const valueFormatter = (params: any) => {
+    if (
+      params.value != null &&
+      params.colDef.cellRenderer === 'ipv4ValueRenderer'
+    ) {
       return formatIpV4(params.value.toString());
     }
-    return params.value.toString();
+    return params.value != null ? params.value.toString() : '';
   };
 
   const percentMetricValueFormatter = function (params: ValueFormatterParams) {
@@ -237,7 +240,7 @@ export default function transformProps(chartProps: CccsGridChartProps) {
         sort: sortDirection,
         sortIndex,
         enableRowGroup,
-        getQuickFilterText: (params: any) => advancedTypeValueFormatter(params),
+        getQuickFilterText: (params: any) => valueFormatter(params),
         headerTooltip: columnDescription,
       };
     });
@@ -264,8 +267,7 @@ export default function transformProps(chartProps: CccsGridChartProps) {
           cellRenderer,
           sortable: isSortable,
           enableRowGroup,
-          getQuickFilterText: (params: any) =>
-            advancedTypeValueFormatter(params),
+          getQuickFilterText: (params: any) => valueFormatter(params),
           headerTooltip: columnDescription,
         };
       });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The value formatter for the cccs-grid quick search did not correctly handle null values causing the search to not work. The bug was described in this ticket: https://cccs.atlassian.net/browse/CLDN-1967?atlOrigin=eyJpIjoiYjc0NmJlZTZiNTc1NGRhN2JiZTNmZmE0YzI3NGI2ODMiLCJwIjoiaiJ9

This fix changes the name of the function to simply valueFormatter (since it is not just handling advanced types but all cell values), and correctly handles null values.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
