### PR TITLE
[CLDN-2320] Added 'operator' to advanced data type endpoint

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:feature_dataset-explorer-chart-update-chart_20230725150622_b7385
+FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.1_20230726145242_b7395
 
 USER root
 

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.1_20230726145242_b7395
+FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-2320_20230830182809_b7567
 
 USER root
 

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-2320_20230906113157_b7630
+FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-2320_20230919164725_b7752
 
 USER root
 

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-2320_20230830182809_b7567
+FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-2320_20230906113157_b7630
 
 USER root
 

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-2320_20231011123216_b7950
+FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-2320_20231012110159_b7971
 
 USER root
 

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-2320_20230919164725_b7752
+FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-2320_20231011123216_b7950
 
 USER root
 

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:feature_CLDN-2320_20231012110159_b7971
+FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.1_20230726145242_b7395
 
 USER root
 

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/components/controls/advancedDataTypeValueControl/index.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-cccs-grid/src/components/controls/advancedDataTypeValueControl/index.tsx
@@ -56,7 +56,7 @@ const AdvancedDataTypeValueControlValueControl: React.FC<Props> = ({
     advancedDataTypesState,
     subjectAdvancedDataType,
     fetchAdvancedDataTypeValueCallback,
-  } = useAdvancedDataTypes(() => {}, default_advanced_data_type_state);
+  } = useAdvancedDataTypes(() => {}, '', default_advanced_data_type_state);
 
   const onChangeWrapper = (selection: any) => {
     setValidationErrors(

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -293,7 +293,7 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
     subjectAdvancedDataType,
     fetchAdvancedDataTypeValueCallback,
     fetchSubjectAdvancedDataType,
-  } = useAdvancedDataTypes(props.validHandler);
+  } = useAdvancedDataTypes(props.validHandler, props.adhocFilter.operatorId);
   // TODO: This does not need to exist, just use the advancedTypeOperatorList list
   const isOperatorRelevantWrapper = (operator: Operators, subject: string) =>
     subjectAdvancedDataType && !advancedDataTypesState.useDefaultOperators

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -293,7 +293,7 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
     subjectAdvancedDataType,
     fetchAdvancedDataTypeValueCallback,
     fetchSubjectAdvancedDataType,
-  } = useAdvancedDataTypes(props.validHandler, props.adhocFilter.operatorId);
+  } = useAdvancedDataTypes(props.validHandler, props.adhocFilter.operator);
   // TODO: This does not need to exist, just use the advancedTypeOperatorList list
   const isOperatorRelevantWrapper = (operator: Operators, subject: string) =>
     subjectAdvancedDataType && !advancedDataTypesState.useDefaultOperators

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/useAdvancedDataTypes.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/useAdvancedDataTypes.ts
@@ -32,6 +32,7 @@ const INITIAL_ADVANCED_DATA_TYPES_STATE: AdvancedDataTypesState = {
 
 const useAdvancedDataTypes = (
   validHandler: (isValid: boolean) => void,
+  selectedAdvancedDataTypeOperator: string | undefined,
   default_state: AdvancedDataTypesState = INITIAL_ADVANCED_DATA_TYPES_STATE,
 ) => {
   const [advancedDataTypesState, setAdvancedDataTypesState] =
@@ -39,6 +40,10 @@ const useAdvancedDataTypes = (
   const [subjectAdvancedDataType, setSubjectAdvancedDataType] = useState<
     string | undefined
   >();
+  const selectedOperator =
+    selectedAdvancedDataTypeOperator === undefined
+      ? ''
+      : selectedAdvancedDataTypeOperator;
 
   const fetchAdvancedDataTypeValueCallback = useCallback(
     (
@@ -56,6 +61,7 @@ const useAdvancedDataTypes = (
         const queryParams = rison.encode({
           type: subjectAdvancedDataType,
           values,
+          operator: selectedOperator,
         });
         const endpoint = `/api/v1/advanced_data_type/convert?q=${queryParams}`;
         SupersetClient.get({ endpoint })
@@ -83,7 +89,7 @@ const useAdvancedDataTypes = (
           });
       }, 600)();
     },
-    [validHandler],
+    [validHandler, selectedOperator],
   );
 
   const fetchSubjectAdvancedDataType = (props: Props) => {

--- a/superset/advanced_data_type/api.py
+++ b/superset/advanced_data_type/api.py
@@ -93,6 +93,7 @@ class AdvancedDataTypeRestApi(BaseSupersetApi):
         item = kwargs["rison"]
         advanced_data_type: str = item["type"]
         values = item["values"]
+        operator = item["operator"]
         addon = ADVANCED_DATA_TYPES.get(advanced_data_type.lower())
         if not addon:
             return self.response(
@@ -105,6 +106,7 @@ class AdvancedDataTypeRestApi(BaseSupersetApi):
         bus_resp: AdvancedDataTypeResponse = addon.translate_type(
             {
                 "values": values,
+                "operator": operator,
             }
         )
         return self.response(200, result=bus_resp)

--- a/superset/advanced_data_type/plugins/internet_address.py
+++ b/superset/advanced_data_type/plugins/internet_address.py
@@ -37,15 +37,17 @@ def cidr_func(req: AdvancedDataTypeRequest) -> AdvancedDataTypeResponse:
         "display_value": "",
         "valid_filter_operators": [
             FilterStringOperators.EQUALS,
+            FilterStringOperators.NOT_EQUALS,
             FilterStringOperators.GREATER_THAN_OR_EQUAL,
             FilterStringOperators.GREATER_THAN,
             FilterStringOperators.IN,
+            FilterStringOperators.NOT_IN,
             FilterStringOperators.LESS_THAN,
             FilterStringOperators.LESS_THAN_OR_EQUAL,
         ],
     }
     if req["values"] == [""]:
-        resp["values"].append("")
+        resp["error_message"] = "IPv4 address or CIDR must not be empty"
         return resp
     for val in req["values"]:
         string_value = str(val)

--- a/superset/advanced_data_type/plugins/internet_address.py
+++ b/superset/advanced_data_type/plugins/internet_address.py
@@ -60,7 +60,7 @@ def cidr_func(req: AdvancedDataTypeRequest) -> AdvancedDataTypeResponse:
             resp["values"].append(
                 {"start": int(ip_range[0]), "end": int(ip_range[-1])}
                 if ip_range[0] != ip_range[-1]
-                else str(ip_range[0])
+                else int(ip_range[0])
             )
         except ValueError as ex:
             resp["error_message"] = str(ex)

--- a/superset/advanced_data_type/plugins/internet_address.py
+++ b/superset/advanced_data_type/plugins/internet_address.py
@@ -60,7 +60,7 @@ def cidr_func(req: AdvancedDataTypeRequest) -> AdvancedDataTypeResponse:
             resp["values"].append(
                 {"start": int(ip_range[0]), "end": int(ip_range[-1])}
                 if ip_range[0] != ip_range[-1]
-                else int(ip_range[0])
+                else str(ip_range[0])
             )
         except ValueError as ex:
             resp["error_message"] = str(ex)

--- a/superset/advanced_data_type/plugins/internet_port.py
+++ b/superset/advanced_data_type/plugins/internet_port.py
@@ -61,15 +61,17 @@ def port_translation_func(req: AdvancedDataTypeRequest) -> AdvancedDataTypeRespo
         "display_value": "",
         "valid_filter_operators": [
             FilterStringOperators.EQUALS,
+            FilterStringOperators.NOT_EQUALS,
             FilterStringOperators.GREATER_THAN_OR_EQUAL,
             FilterStringOperators.GREATER_THAN,
             FilterStringOperators.IN,
+            FilterStringOperators.NOT_IN,
             FilterStringOperators.LESS_THAN,
             FilterStringOperators.LESS_THAN_OR_EQUAL,
         ],
     }
     if req["values"] == [""]:
-        resp["values"].append([""])
+        resp["error_message"] = "Port must not be empty"
         return resp
     for val in req["values"]:
         string_value = str(val)

--- a/superset/advanced_data_type/plugins/internet_port.py
+++ b/superset/advanced_data_type/plugins/internet_port.py
@@ -27,27 +27,27 @@ from superset.advanced_data_type.types import (
 from superset.utils.core import FilterOperator, FilterStringOperators
 
 port_conversion_dict: Dict[str, List[int]] = {
-    "http": [80],
-    "ssh": [22],
-    "https": [443],
-    "ftp": [20, 21],
-    "ftps": [989, 990],
-    "telnet": [23],
-    "telnets": [992],
-    "smtp": [25],
-    "submissions": [465],  # aka smtps, ssmtp, urd
-    "kerberos": [88],
-    "kerberos-adm": [749],
-    "poperator3": [110],
-    "poperator3s": [995],
-    "nntp": [119],
-    "nntps": [563],
-    "ntp": [123],
-    "snmp": [161],
-    "ldap": [389],
-    "ldaps": [636],
-    "imap2": [143],  # aka imap
-    "imaps": [993],
+    "http": ["80"],
+    "ssh": ["22"],
+    "https": ["443"],
+    "ftp": ["20", "21"],
+    "ftps": ["989", "990"],
+    "telnet": ["23"],
+    "telnets": ["992"],
+    "smtp": ["25"],
+    "submissions": ["465"],  # aka smtps, ssmtp, urd
+    "kerberos": ["88"],
+    "kerberos-adm": ["749"],
+    "poperator3": ["110"],
+    "poperator3s": ["995"],
+    "nntp": ["119"],
+    "nntps": ["563"],
+    "ntp": ["123"],
+    "snmp": ["161"],
+    "ldap": ["389"],
+    "ldaps": ["636"],
+    "imap2": ["143"],  # aka imap
+    "imaps": ["993"],
 }
 
 
@@ -80,7 +80,7 @@ def port_translation_func(req: AdvancedDataTypeRequest) -> AdvancedDataTypeRespo
                 if not 1 <= int(string_value) <= 65535:
                     raise ValueError
             resp["values"].append(
-                [int(string_value)]
+                [string_value]
                 if string_value.isnumeric()
                 else port_conversion_dict[string_value]
             )

--- a/superset/advanced_data_type/plugins/internet_port.py
+++ b/superset/advanced_data_type/plugins/internet_port.py
@@ -27,27 +27,27 @@ from superset.advanced_data_type.types import (
 from superset.utils.core import FilterOperator, FilterStringOperators
 
 port_conversion_dict: Dict[str, List[int]] = {
-    "http": ["80"],
-    "ssh": ["22"],
-    "https": ["443"],
-    "ftp": ["20", "21"],
-    "ftps": ["989", "990"],
-    "telnet": ["23"],
-    "telnets": ["992"],
-    "smtp": ["25"],
-    "submissions": ["465"],  # aka smtps, ssmtp, urd
-    "kerberos": ["88"],
-    "kerberos-adm": ["749"],
-    "poperator3": ["110"],
-    "poperator3s": ["995"],
-    "nntp": ["119"],
-    "nntps": ["563"],
-    "ntp": ["123"],
-    "snmp": ["161"],
-    "ldap": ["389"],
-    "ldaps": ["636"],
-    "imap2": ["143"],  # aka imap
-    "imaps": ["993"],
+    "http": [80],
+    "ssh": [22],
+    "https": [443],
+    "ftp": [20, 21],
+    "ftps": [989, 990],
+    "telnet": [23],
+    "telnets": [992],
+    "smtp": [25],
+    "submissions": [465],  # aka smtps, ssmtp, urd
+    "kerberos": [88],
+    "kerberos-adm": [749],
+    "poperator3": [110],
+    "poperator3s": [995],
+    "nntp": [119],
+    "nntps": [563],
+    "ntp": [123],
+    "snmp": [161],
+    "ldap": [389],
+    "ldaps": [636],
+    "imap2": [143],  # aka imap
+    "imaps": [993],
 }
 
 
@@ -80,7 +80,7 @@ def port_translation_func(req: AdvancedDataTypeRequest) -> AdvancedDataTypeRespo
                 if not 1 <= int(string_value) <= 65535:
                     raise ValueError
             resp["values"].append(
-                [string_value]
+                [int(string_value)]
                 if string_value.isnumeric()
                 else port_conversion_dict[string_value]
             )

--- a/superset/advanced_data_type/schemas.py
+++ b/superset/advanced_data_type/schemas.py
@@ -28,8 +28,9 @@ advanced_data_type_convert_schema = {
             "items": {"default": "http"},
             "minItems": 0,
         },
+        "operator": {"type": "string", "default": "=="},
     },
-    "required": ["type", "values"],
+    "required": ["type", "values", "operator"],
 }
 
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1528,6 +1528,7 @@ class SqlaTable(Model, BaseDatasource):  # pylint: disable=too-many-public-metho
                         {
                             "type": col_advanced_data_type,
                             "values": values,
+                            "operator": op,
                         }
                     )
                     if bus_resp["error_message"]:

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1724,6 +1724,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                         {
                             "type": col_advanced_data_type,
                             "values": values,
+                            "operator": op,
                         }
                     )
                     if bus_resp["error_message"]:

--- a/tests/integration_tests/advanced_data_type/api_tests.py
+++ b/tests/integration_tests/advanced_data_type/api_tests.py
@@ -83,21 +83,11 @@ def test_types_type_request(test_client, login_as_admin):
     assert data == {"result": ["type"]}
 
 
-def test_types_convert_bad_request_no_vals(test_client, login_as_admin):
-    """
-    Advanced Data Type API: Test request to see if it behaves as expected when no values are passed
-    """
-    arguments = {"type": "type", "values": []}
-    uri = f"api/v1/advanced_data_type/convert?q={prison.dumps(arguments)}"
-    response_value = test_client.get(uri)
-    assert response_value.status_code == 400
-
-
 def test_types_convert_bad_request_no_type(test_client, login_as_admin):
     """
     Advanced Data Type API: Test request to see if it behaves as expected when no type is passed
     """
-    arguments = {"type": "", "values": [1]}
+    arguments = {"type": "", "values": [1], "operator": "TEST_OPERATOR"}
     uri = f"api/v1/advanced_data_type/convert?q={prison.dumps(arguments)}"
     response_value = test_client.get(uri)
     assert response_value.status_code == 400
@@ -112,7 +102,7 @@ def test_types_convert_bad_request_type_not_found(test_client, login_as_admin):
     Advanced Data Type API: Test request to see if it behaves as expected when passed in type is
     not found/not valid
     """
-    arguments = {"type": "not_found", "values": [1]}
+    arguments = {"type": "not_found", "values": [1], "operator": "TEST_OPERATOR"}
     uri = f"api/v1/advanced_data_type/convert?q={prison.dumps(arguments)}"
     response_value = test_client.get(uri)
     assert response_value.status_code == 400
@@ -127,7 +117,7 @@ def test_types_convert_request(test_client, login_as_admin):
     Advanced Data Type API: Test request to see if it behaves as expected when a valid type
     and valid values are passed in
     """
-    arguments = {"type": "type", "values": [1]}
+    arguments = {"type": "type", "values": [1], "operator": "TEST_OPERATOR"}
     uri = f"api/v1/advanced_data_type/convert?q={prison.dumps(arguments)}"
     response_value = test_client.get(uri)
     assert response_value.status_code == 200


### PR DESCRIPTION
This PR incorporates the changes that are required in the CLDN-2320 ticket ([link](https://cccs.atlassian.net/browse/CLDN-2320))

**Major Changes Include:**

- Updated the `/convert` endpoint so that it also returns the currently selected operator instead of just the user entered value