### PR TITLE
feat/FLOW-13 Option for default action on cell selection

### DIFF
--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
@@ -32,7 +32,10 @@ import CopyMenuItem from './ContextMenu/MenuItems/CopyMenuItem';
 import CopyWithHeaderMenuItem from './ContextMenu/MenuItems/CopyWithHeaderMenuItem';
 import EmitFilterMenuItem from './ContextMenu/MenuItems/EmitFilterMenuItem';
 
-import { PAGE_SIZE_OPTIONS } from '../cccs-grid/plugin/controlPanel';
+import {
+  PAGE_SIZE_OPTIONS,
+  DEFAULT_CLICK_ACTIONS,
+} from '../cccs-grid/plugin/controlPanel';
 
 import { AGGridVizProps } from '../types';
 
@@ -62,6 +65,7 @@ export default function AGGridViz({
   enableGrouping,
   setDataMask,
   principalColumns,
+  onClickBehaviour,
   agGridLicenseKey,
   emitCrossFilters,
 }: AGGridVizProps) {
@@ -85,7 +89,12 @@ export default function AGGridViz({
   const [rowDataStateful, setrowDataStateful] = useState(rowData);
   const [isDestroyed, setIsDestroyed] = useState(false);
   const [contextDivID] = useState(Math.random());
-  // const exploreState = useSelector((state: ExplorePageState) => state.explore);
+  const [emitCrossFiltersStateful, setEmitCrossFiltersStateful] =
+    useState<boolean>(emitCrossFilters);
+
+  useEffect(() => {
+    setEmitCrossFiltersStateful(emitCrossFilters);
+  }, [emitCrossFilters]);
 
   useEffect(() => {
     setColumnDefsStateful(columnDefs);
@@ -127,6 +136,57 @@ export default function AGGridViz({
       setSearchValue('');
     }
   }, [includeSearch]);
+
+  const emitFilter = useCallback(
+    Data => {
+      const groupBy = Object.keys(Data);
+      const groupByValues = Object.values(Data);
+      setDataMask({
+        extraFormData: {
+          filters:
+            groupBy.length === 0
+              ? []
+              : groupBy.map(col => {
+                  const val = ensureIsArray(Data?.[col]);
+                  if (val === null || val === undefined)
+                    return {
+                      col,
+                      op: 'IS NULL',
+                    };
+                  return {
+                    col,
+                    op: 'IN',
+                    val,
+                  };
+                }),
+        },
+        filterState: {
+          value: groupByValues.length ? groupByValues : null,
+        },
+      });
+    },
+    [setDataMask],
+  ); // only take relevant page size options
+
+  const handleOnClickBehavior = (
+    highlightedData: DataMap,
+    principalData: DataMap,
+  ) => {
+    const to_emit = emitCrossFiltersStateful;
+    // handle default click behaviour
+    if (onClickBehaviour !== 'None') {
+      // get action
+      const action = DEFAULT_CLICK_ACTIONS.find(
+        a => a.verbose_name === onClickBehaviour,
+      )?.action_name;
+      // handle action
+      if (action === 'emit_filters' && to_emit) {
+        emitFilter(highlightedData);
+      } else if (action === 'emit_principal_filters' && to_emit) {
+        emitFilter(principalData);
+      }
+    }
+  };
 
   const onRangeSelectionChanged = useCallback(
     (event: RangeSelectionChangedEvent) => {
@@ -176,40 +236,10 @@ export default function AGGridViz({
         highlightedData: newSelectedData,
         principalData,
       });
+      handleOnClickBehavior(newSelectedData, principalData);
     },
-    [],
+    [emitCrossFiltersStateful],
   );
-
-  const emitFilter = useCallback(
-    Data => {
-      const groupBy = Object.keys(Data);
-      const groupByValues = Object.values(Data);
-      setDataMask({
-        extraFormData: {
-          filters:
-            groupBy.length === 0
-              ? []
-              : groupBy.map(col => {
-                  const val = ensureIsArray(Data?.[col]);
-                  if (val === null || val === undefined)
-                    return {
-                      col,
-                      op: 'IS NULL',
-                    };
-                  return {
-                    col,
-                    op: 'IN',
-                    val,
-                  };
-                }),
-        },
-        filterState: {
-          value: groupByValues.length ? groupByValues : null,
-        },
-      });
-    },
-    [setDataMask],
-  ); // only take relevant page size options
 
   const onClick = (data: DataMap) => {
     emitFilter(data);
@@ -260,7 +290,7 @@ export default function AGGridViz({
         onSelection={handleContextMenuSelected}
       />,
     ];
-    if (emitCrossFilters) {
+    if (emitCrossFiltersStateful) {
       menuItems = [
         ...menuItems,
         <EmitFilterMenuItem

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/cccs-grid/plugin/controlPanel.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/cccs-grid/plugin/controlPanel.tsx
@@ -45,6 +45,19 @@ export const PAGE_SIZE_OPTIONS = formatSelectOptions<number>([
   200,
 ]);
 
+export const DEFAULT_CLICK_ACTIONS = [
+  { verbose_name: 'None', action_name: 'none' },
+  { verbose_name: 'Emit Filters', action_name: 'emit_filters' },
+  {
+    verbose_name: 'Emit Principal Filters',
+    action_name: 'emit_principal_filters',
+  },
+];
+
+const DEFAULT_CLICK_ACTIONS_OPTIONS = formatSelectOptions(
+  DEFAULT_CLICK_ACTIONS.map(o => o.verbose_name),
+);
+
 /**
  * Visibility check
  */
@@ -306,6 +319,22 @@ const config: ControlPanelConfig = {
             name: 'timeseries_limit_metric',
             override: {
               visibility: isAggMode,
+            },
+          },
+        ],
+        [
+          {
+            name: 'on_click_behaviour',
+            config: {
+              type: 'SelectControl',
+              freeForm: false,
+              renderTrigger: false,
+              label: t('Default click behaviour'),
+              default: 'None',
+              choices: DEFAULT_CLICK_ACTIONS_OPTIONS,
+              description: t(
+                'Select an action to occur by default when a cell/row is clicked. Actions are from the right-click context menu. Default is to do nothing.',
+              ),
             },
           },
         ],

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/cccs-grid/plugin/transformProps.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/cccs-grid/plugin/transformProps.ts
@@ -158,6 +158,7 @@ export default function transformProps(chartProps: CccsTableChartProps) {
     enableGrouping,
     enableJsonExpand,
     principalColumns,
+    onClickBehaviour,
   }: CccsTableFormData = {
     ...formData,
   };
@@ -169,7 +170,7 @@ export default function transformProps(chartProps: CccsTableChartProps) {
     formData.queryMode === 'raw'
       ? formData.allColumns || []
       : formData.groupby || [];
-  const metrics = formData.metrics;
+  const { metrics } = formData;
   const percent_metrics = formData.percentMetrics;
 
   let columnDefs = calcColumnColumnDefs(
@@ -227,6 +228,7 @@ export default function transformProps(chartProps: CccsTableChartProps) {
     pageLength,
     enableGrouping,
     principalColumns,
+    onClickBehaviour,
     agGridLicenseKey,
     setDataMask,
     emitCrossFilters,

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/types/index.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/types/index.ts
@@ -14,6 +14,7 @@ export type CccsTableFormData = QueryFormData & {
   emitCrossFilters: boolean;
   principalColumns: string[];
   percent_metrics: string[];
+  onClickBehaviour: string;
 };
 
 export type CccsTableChartProps = ChartProps & {
@@ -32,12 +33,12 @@ export type AGGridVizProps = {
   enableRowNumbers: boolean;
   enableGrouping: boolean;
   principalColumns: string[];
+  onClickBehaviour: string;
   agGridLicenseKey: string;
   emitCrossFilters: boolean;
   setDataMask: SetDataMaskHook;
 };
 
-export interface AgGridChartDataResponseResult
-  extends ChartDataResponseResult {
+export interface AgGridChartDataResponseResult extends ChartDataResponseResult {
   agGridLicenseKey: string;
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We want to be able to make it so that a certain action happens when a user clicks a cell/row such as emitting principle columns. This PR adds a control to the cccs-chart viz to specify which supported action they want to take place for that chart

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
