### PR TITLE
Fix: return fission response directly from fission proxy api endpoint

### DIFF
--- a/superset/fission/api.py
+++ b/superset/fission/api.py
@@ -75,7 +75,7 @@ class FissionRestApi(BaseApi):
           "X-Auth-Request-Access-Token": token
         }
 
-        url = request_url.replace(f'{request.host_url}api/v1/fission', f'{API_HOST}/')
+        url = request.url.replace(f'{request.host_url}api/v1/fission', f'{API_HOST}/')
         res = requests.request(  # ref. https://stackoverflow.com/a/36601467/248616
             method          = request.method,
             url             = url,
@@ -84,8 +84,4 @@ class FissionRestApi(BaseApi):
             headers         = headers,
             timeout         = 180 # extending timeout for fission loading times
         )
-        try:
-          result = res.json()
-        except:
-          result = str(res.text)
-        return self.response(res.status_code, result=result)
+        return res


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This will possibly help with the iframe chart by providing a way to call fission using the superset backend as a proxy

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
