### PR TITLE
fix/CLDN-2434 Metric causing error in AG-Grid

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:fix_CLDN-2434-Metrics-in-CCCS-Grid_20240119211630_b8775
+FROM uchimera.azurecr.io/cccs/superset-base:fix_CLDN-2434-Metrics-in-CCCS-Grid_20240124184016_b8834
 
 USER root
 

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.1_20231120161654_b8285
+FROM uchimera.azurecr.io/cccs/superset-base:fix_CLDN-2434-Metrics-in-CCCS-Grid_20240119211630_b8775
 
 USER root
 

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/cccs-grid/plugin/transformProps.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/cccs-grid/plugin/transformProps.ts
@@ -39,9 +39,9 @@ const calcMetricColumnDefs = (
     const metricsColumnDefs = metrics.map((metric: any) => {
       const metricHeader = metricVerboseNameMap[metric]
         ? metricVerboseNameMap[metric]
-        : metric;
+        : metric.label;
       return {
-        field: metric,
+        field: metric.label,
         headerName: metricHeader,
         sortable: true,
         enableRowGroup: true,
@@ -54,9 +54,9 @@ const calcMetricColumnDefs = (
     const percentMetricsColumnDefs = percent_metrics.map((metric: any) => {
       const metricHeader = metricVerboseNameMap[metric]
         ? metricVerboseNameMap[metric]
-        : metric;
+        : metric.label;
       return {
-        field: `%${metric}`,
+        field: `%${metric.label}`,
         headerName: `%${metricHeader}`,
         sortable: true,
         valueFormatter: percentMetricValueFormatter,

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/cccs-grid/plugin/transformProps.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/cccs-grid/plugin/transformProps.ts
@@ -37,11 +37,12 @@ const calcMetricColumnDefs = (
 
   if (metrics) {
     const metricsColumnDefs = metrics.map((metric: any) => {
+      const metricLabel = metric.label ? metric.label : metric
       const metricHeader = metricVerboseNameMap[metric]
         ? metricVerboseNameMap[metric]
-        : metric.label;
+        : metricLabel;
       return {
-        field: metric.label,
+        field: metricLabel,
         headerName: metricHeader,
         sortable: true,
         enableRowGroup: true,
@@ -52,11 +53,12 @@ const calcMetricColumnDefs = (
 
   if (percent_metrics) {
     const percentMetricsColumnDefs = percent_metrics.map((metric: any) => {
+      const metricLabel = metric.label ? metric.label : metric
       const metricHeader = metricVerboseNameMap[metric]
         ? metricVerboseNameMap[metric]
-        : metric.label;
+        : metricLabel;
       return {
-        field: `%${metric.label}`,
+        field: `%${metricLabel}`,
         headerName: `%${metricHeader}`,
         sortable: true,
         valueFormatter: percentMetricValueFormatter,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The metrics in CCCS grid were not being transformed properly. The entire metric object was being passed to the ag grid as the column name instead of just the metric label. Small quick fix to use the metric label as the column name and header.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Control Panel:
![image](https://github.com/CybercentreCanada/superset/assets/102618419/2479779f-3e72-481d-b7cc-d9e8f816c420)

Before
![image](https://github.com/apache/superset/assets/102618419/13633811-1aaa-4526-91c0-cbd51a6c3854)
After
![image](https://github.com/apache/superset/assets/102618419/befb64a1-fcda-4401-88a1-7befc76a75a6)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
