### PR TITLE
CLDN-2447 Add suppressFieldDotNotation flag to ag grid

### DIFF
--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
@@ -556,6 +556,7 @@ export default function AGGridViz({
           cacheQuickFilter
           suppressRowClickSelection
           suppressContextMenu
+          suppressFieldDotNotation
           modules={[
             ClientSideRowModelModule,
             RangeSelectionModule,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Columns with '.' in them do not show up properly in AG-Grid due to it trying to use Field Dot Notation: https://www.ag-grid.com/javascript-data-grid/column-definitions/#accessing-row-data-values. I do not think it is even possible to use this feature in superset so I think it is best to disable it.

This PR adds the suppressFieldDotNotation flag to the ag grid component to avoid this behavior and properly render column names with '.' in them. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
