### PR TITLE
bug/CLDN-2472

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:bug_CLDN-2472_20240320142017_b9616
+FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.1_20240307150640_b9509
 USER root
 
 COPY *requirements.txt /tmp/

--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:cccs-2.1_20240307150640_b9509
+FROM uchimera.azurecr.io/cccs/superset-base:bug_CLDN-2472_20240320142017_b9616
 USER root
 
 COPY *requirements.txt /tmp/

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-dataset-explorer/src/plugin/transformProps.ts
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-dataset-explorer/src/plugin/transformProps.ts
@@ -261,7 +261,7 @@ export default function transformProps(chartProps: CccsGridChartProps) {
     };
   
     if (metrics) {
-      const metricsColumnDefs = formData.metrics.map((metric: any) => {
+      const metricsColumnDefs = formData.metrics?.map((metric: any) => {
         const metricLabel = metric.label ? metric.label : metric
         const metricHeader = metricVerboseNameMap[metric]
           ? metricVerboseNameMap[metric]
@@ -273,7 +273,7 @@ export default function transformProps(chartProps: CccsGridChartProps) {
           enableRowGroup: true,
         };
       });
-      columnDefs = columnDefs.concat(metricsColumnDefs);
+      columnDefs = columnDefs.concat(metricsColumnDefs || []);
     }
   
     if (formData.percent_metrics) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Error with Dataset Explorer when in Aggregate mode. When running the query the chart fails to load because the metrics do not exist in this chart type. I added a default value for this case

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
