### PR TITLE
Feature/Flow 8 

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -87,6 +87,7 @@
         "dom-to-pdf": "^0.3.2",
         "emotion-rgba": "0.0.9",
         "fast-glob": "^3.2.7",
+        "file-saver": "^2.0.5",
         "fontsource-fira-code": "^4.0.0",
         "fs-extra": "^10.0.0",
         "fuse.js": "^6.4.6",
@@ -31368,6 +31369,11 @@
       "engines": {
         "node": ">=8.9.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/file-system-cache": {
       "version": "1.0.5",
@@ -85184,6 +85190,11 @@
           }
         }
       }
+    },
+    "file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "file-system-cache": {
       "version": "1.0.5",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -150,6 +150,7 @@
     "dom-to-pdf": "^0.3.2",
     "emotion-rgba": "0.0.9",
     "fast-glob": "^3.2.7",
+    "file-saver": "^2.0.5",
     "fontsource-fira-code": "^4.0.0",
     "fs-extra": "^10.0.0",
     "fuse.js": "^6.4.6",

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
@@ -45,6 +45,7 @@ import EmitIcon from '../../../components/EmitIcon';
 import { AGGridVizProps, DataMap, GridData } from '../types';
 import ExportMenu from './ContextMenu/MenuItems/ExportMenu';
 import { getJumpToDashboardContextMenuItems } from './JumpActionConfigControl/utils';
+import DownloadEmailMenuItem from './ContextMenu/MenuItems/DownloadEmailMenuItem';
 import OpenInAssemblyLineMenuItem from './ContextMenu/MenuItems/OpenInAssemblyLineMenuItem';
 
 // Register the required feature modules with the Grid
@@ -407,6 +408,20 @@ export default function AGGridViz({
           key="open-file-in-assembly-line"
           data={selectedData.typeData.file_sha256}
           base_url={assemblyLineUrl}
+        />,
+      ];
+    }
+    if (
+      selectedData.typeData.eml_path &&
+      selectedData.typeData.eml_path.length > 0
+    ) {
+      specialMenuItems = [
+        ...specialMenuItems,
+        <DownloadEmailMenuItem
+          onSelection={handleContextMenu}
+          label="Download Email"
+          key="download-email"
+          data={selectedData.typeData.eml_path[0]}
         />,
       ];
     }

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/ContextMenu/MenuItems/DownloadEmailMenuItem.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/ContextMenu/MenuItems/DownloadEmailMenuItem.tsx
@@ -1,0 +1,97 @@
+import { SupersetClient } from '@superset-ui/core';
+import React from 'react';
+import { saveAs } from 'file-saver';
+import { Menu } from 'src/components/Menu';
+import { useDispatch } from 'react-redux';
+import {
+  addInfoToast,
+  addDangerToast,
+} from 'src/components/MessageToasts/actions';
+import Icon from '@ant-design/icons';
+import EmailSvg from '../../../cccs-grid/images/email.svg';
+
+interface DownloadEmailMenuItemProps {
+  label: string;
+  data: string;
+  onSelection: () => void;
+  key?: string;
+  disabled?: boolean;
+  isContextMenu?: boolean;
+  contextMenuY?: number;
+}
+
+export default function DownloadEmailMenuItem(
+  props: DownloadEmailMenuItemProps,
+) {
+  const dispatch = useDispatch();
+
+  const onClick = () => {
+    const endpoint = `/api/v1/fission/get-eml?file=${props.data}`;
+    dispatch(addInfoToast('Download started'));
+
+    SupersetClient.get({ endpoint, timeout: 180000 }) // 3 minutes
+      .then(({ json }) => {
+        if (json.result?.content?.indexOf('base64') !== -1) {
+          // Check for base64 encoding
+          const b64Data = json.result.content.split(',')[1];
+          const contentType = 'message/rfc822'; // Correct MIME type for EML files
+
+          // Convert base64 data to a blob with the appropriate MIME type
+          const blob = b64ToBlob(b64Data, contentType);
+
+          // Derive file name from the title or use a default name, ensuring it ends with .eml
+          const uniqueTitle = json.result.title
+            ? `${json.result.title}.eml`
+            : 'downloaded_eml_file.eml';
+
+          // Use FileSaver or a similar library to trigger the file download
+          saveAs(blob, uniqueTitle);
+        } else if (json.result?.content) {
+          dispatch(addDangerToast('Invalid file format.'));
+        } else {
+          dispatch(addDangerToast('No content to download.'));
+        }
+      })
+      .catch(error => {
+        const errorMessage = `Download failed: ${error.message}`;
+        dispatch(addDangerToast(errorMessage));
+      });
+
+    props.onSelection();
+  };
+
+  return (
+    <Menu.Item
+      onClick={onClick}
+      className={
+        props.disabled
+          ? 'ant-dropdown-menu-item ant-dropdown-menu-item-disabled'
+          : 'ant-dropdown-menu-item'
+      }
+      disabled={props.disabled}
+      icon={<Icon component={EmailSvg} />}
+    >
+      {props.label}
+    </Menu.Item>
+  );
+}
+
+function b64ToBlob(b64Data: string, contentType = '', sliceSize = 512) {
+  const byteCharacters = atob(b64Data);
+  const byteArrays = [];
+
+  for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+    const slice = byteCharacters.slice(offset, offset + sliceSize);
+
+    const byteNumbers = new Array(slice.length);
+    for (let i = 0; i < slice.length; i += 1) {
+      byteNumbers[i] = slice.charCodeAt(i);
+    }
+
+    const byteArray = new Uint8Array(byteNumbers);
+    byteArrays.push(byteArray);
+  }
+
+  const blob = new Blob(byteArrays, { type: contentType });
+  return blob;
+}

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/cccs-grid/images/email.svg
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/cccs-grid/images/email.svg
@@ -1,0 +1,39 @@
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 64 64" enable-background="new 0 0 64 64" xml:space="preserve">
+<g>
+	<g>
+		<g>
+			<path fill="#316CFF" d="M32,0c17.7,0,32,14.3,32,32S49.7,64,32,64S0,49.7,0,32S14.3,0,32,0z"></path>
+		</g>
+	</g>
+	<g>
+		<g>
+			<polygon fill="#FFD41D" points="32,9 13,22 13,35 32,35 51,35 51,22 			"></polygon>
+		</g>
+	</g>
+	<g>
+		<g>
+			<path fill="#FFFFFF" d="M45,13v30c0,0.5-0.5,1-1,1H20c-0.5,0-1-0.5-1-1V13c0-0.6,0.5-1,1-1h24C44.5,12,45,12.4,45,13z"></path>
+		</g>
+	</g>
+	<g>
+		<g>
+			<path fill="#D3D5DD" d="M40.1,18c0.5,0,0.9,0.5,0.9,1s-0.4,1-0.9,1H23.9c-0.5,0-0.9-0.5-0.9-1s0.4-1,0.9-1H40.1z"></path>
+		</g>
+	</g>
+	<g>
+		<g>
+			<path fill="#D3D5DD" d="M40.1,23c0.5,0,0.9,0.5,0.9,1s-0.4,1-0.9,1H23.9c-0.5,0-0.9-0.5-0.9-1s0.4-1,0.9-1H40.1z"></path>
+		</g>
+	</g>
+	<g>
+		<g>
+			<polygon fill="#D1D5DB" points="32,35 13,22 13,48 51,48 51,22 			"></polygon>
+		</g>
+	</g>
+	<g>
+		<g>
+			<path fill="#E1E5EA" d="M51,48L35.2,32.2h-6.4L13,48H51z"></path>
+		</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
### SUMMARY
In relation to this ticket: https://cccs.atlassian.net/browse/CLDN-2163
Users should be able to right-click on a row containing a path to an EML file on the Email Harmonized Dashboard and retrieve that file via a dropdown menu item within Ag-grid.  The download will start and inform the user if the download was successful or not.  

Deliverables:
A deployment of Superset that allows users to retrieve EML files.
A version of the Email Triaging Dashboard that allows users to retrieve EML files.

### TESTING INSTRUCTIONS
1.  Go on Superset-stg
2.  In the main view, right click on a row and then click 'Download Email'
3. Download should start

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ x] Required feature flags:
- [ x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API