### PR TITLE
CLDN-2433 Allowing user to apply global filter on timestamps

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:bug_CLDN-2432_20240423155517_b9864
+FROM uchimera.azurecr.io/cccs/superset-base:fix_CLDN-2433_20240430184410_b9930
 USER root
 
 COPY *requirements.txt /tmp/

--- a/superset-frontend/src/cccs-viz/plugins/hooks/useEmitGlobalFilter.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/hooks/useEmitGlobalFilter.tsx
@@ -64,7 +64,7 @@ const useEmitGlobalFilter = () => {
 
               const formattedComparator = Array.isArray(processedValue)
                 ? processedValue.map((c: any) =>
-                    colData?.[col]?.valueFormatter
+                    colData?.[col]?.useValueFormatterForExport
                       ? colData?.[col]?.valueFormatter(c)
                       : c,
                   )

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
@@ -317,12 +317,7 @@ export default function AGGridViz({
           }}
           onSelection={handleContextMenu}
           label="Filter On Selection"
-          disabled={
-            !adhocFiltersInScope.length ||
-            Object.values(selectedData.selectedColData).every(
-              data => data.isDateColumn,
-            )
-          }
+          disabled={!adhocFiltersInScope.length}
           key="filter-on-selection"
           icon={
             <FilterOutlined
@@ -335,8 +330,6 @@ export default function AGGridViz({
               : Object.values(selectedData.selectedColData).every(
                   data => data.isDateColumn,
                 )
-              ? 'Date/Time columns cannot be filtered on selection. Use the filter bar to select a date range'
-              : adhocFiltersInScope.length > 1
               ? `Will apply selection to adhoc filters: ${adhocFiltersInScope
                   .map(f => f.name)
                   .join(', ')}`


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
small fix to 'undisable' the filter context option when selecting a date column in ag grid
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
