### PR TITLE
Bug/cldn 2068

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:cccs-3.1_20240522142342_b10174
+FROM uchimera.azurecr.io/cccs/superset-base:bug_cldn-2068_20240530191603_b10239
 
 USER root
 

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
@@ -8,6 +8,7 @@ import React, {
 
 import 'ag-grid-enterprise';
 
+import { theme } from 'src/preamble';
 import { AgGridReact, AgGridReact as AgGridReactType } from 'ag-grid-react';
 
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
@@ -49,7 +50,6 @@ import { getJumpToDashboardContextMenuItems } from './JumpActionConfigControl/ut
 import DownloadEmailMenuItem from './ContextMenu/MenuItems/DownloadEmailMenuItem';
 import OpenInAssemblyLineMenuItem from './ContextMenu/MenuItems/OpenInAssemblyLineMenuItem';
 import SubmitToAssemblyLineMenuItem from './ContextMenu/MenuItems/SubmitToAssemblyLineMenuItem';
-import { theme } from 'src/preamble';
 
 // Register the required feature modules with the Grid
 ModuleRegistry.registerModules([

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
@@ -49,6 +49,7 @@ import { getJumpToDashboardContextMenuItems } from './JumpActionConfigControl/ut
 import DownloadEmailMenuItem from './ContextMenu/MenuItems/DownloadEmailMenuItem';
 import OpenInAssemblyLineMenuItem from './ContextMenu/MenuItems/OpenInAssemblyLineMenuItem';
 import SubmitToAssemblyLineMenuItem from './ContextMenu/MenuItems/SubmitToAssemblyLineMenuItem';
+import { theme } from 'src/preamble';
 
 // Register the required feature modules with the Grid
 ModuleRegistry.registerModules([
@@ -79,7 +80,7 @@ const paginationStyles = css`
 `;
 
 const highlightedCell = css`
-  background-color: rgba(255, 223, 186, 0.5); /* Light orange background */
+  background-color: ${theme.colors.primary.light3};
 `;
 
 export default function AGGridViz({
@@ -108,7 +109,7 @@ export default function AGGridViz({
 
   const getCellClass = useCallback(
     params => {
-      if (crossFilterValue && crossFilterValue.includes(params.value)) {
+      if (crossFilterValue?.includes(params.value)) {
         return highlightedCell;
       }
       return '';


### PR DESCRIPTION

### SUMMARY
This pull request introduces a visual cue for the CCCS Grid to indicate which elements have been emitted as cross-filters. This enhancement aligns the CCCS Grid with other chart types that already provide visual cues, improving user experience by making it easier to track the state of the dashboard.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
