### PR TITLE
Bug/cldn 2053

### DIFF
--- a/cccs-build/superset/Dockerfile
+++ b/cccs-build/superset/Dockerfile
@@ -1,7 +1,7 @@
 # Vault CA container import
 ARG VAULT_CA_CONTAINER=uchimera.azurecr.io/cccs/hogwarts/vault-ca:master_11376_a25c34e1
 FROM $VAULT_CA_CONTAINER AS vault_ca
-FROM uchimera.azurecr.io/cccs/superset-base:bug_CLDN-2445_20240521191045_b10149
+FROM uchimera.azurecr.io/cccs/superset-base:bug_cldn-2053_20240708212153_b10442
 
 USER root
 

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
@@ -2,6 +2,7 @@ import React, {
   ChangeEvent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -35,6 +36,8 @@ import { addWarningToast } from 'src/components/MessageToasts/actions';
 import ChartContextMenu, {
   Ref as ContextRef,
 } from './ContextMenu/AGGridContextMenu';
+import CustomHeader from './CustomHeader/customHeader';
+import "./CustomHeader/customHeaderStyles.css";
 
 import CopyMenuItem from './ContextMenu/MenuItems/CopyMenuItem';
 import CopyWithHeaderMenuItem from './ContextMenu/MenuItems/CopyWithHeaderMenuItem';
@@ -68,11 +71,6 @@ const DEFAULT_COL_DEF = {
 const RETENTION_LIMIT = 100;
 const SUBMISSION_LIMIT = 10;
 const DOWNLOAD_LIMIT = 10;
-
-const headerStyles = css`
-  display: flex;
-  flex-direction: row;
-`;
 
 const paginationStyles = css`
   margin-right: 0.5rem;
@@ -614,6 +612,12 @@ export default function AGGridViz({
     return menuItems;
   };
 
+  const components = useMemo(() => {
+    return {
+      agColumnHeader: CustomHeader,
+    };
+  }, []);
+
   return !isDestroyed ? (
     <>
       <ChartContextMenu
@@ -637,7 +641,7 @@ export default function AGGridViz({
           className="form-inline"
           style={{ flex: '0 1 auto', paddingBottom: '0.5em' }}
         >
-          <div css={headerStyles}>
+          <div className="headerStyles">
             {pageLength > 0 && (
               <span
                 className="dt-select-page-size form-inline"
@@ -690,6 +694,7 @@ export default function AGGridViz({
           enableRangeSelection
           rowData={rowData}
           enableBrowserTooltips
+          components={components}
           onRangeSelectionChanged={onRangeSelectionChanged}
           cacheQuickFilter
           suppressRowClickSelection

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
@@ -612,11 +612,12 @@ export default function AGGridViz({
     return menuItems;
   };
 
-  const components = useMemo(() => {
-    return {
+  const components = useMemo(
+    () => ({
       agColumnHeader: CustomHeader,
-    };
-  }, []);
+    }),
+    [],
+  );
 
   return !isDestroyed ? (
     <>

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/AGGridViz.tsx
@@ -37,7 +37,7 @@ import ChartContextMenu, {
   Ref as ContextRef,
 } from './ContextMenu/AGGridContextMenu';
 import CustomHeader from './CustomHeader/customHeader';
-import "./CustomHeader/customHeaderStyles.css";
+import './CustomHeader/customHeaderStyles.css';
 
 import CopyMenuItem from './ContextMenu/MenuItems/CopyMenuItem';
 import CopyWithHeaderMenuItem from './ContextMenu/MenuItems/CopyWithHeaderMenuItem';

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
@@ -44,29 +44,35 @@ export default props => {
 
   if (props.enableSorting) {
     sort = (
-      <React.Fragment>
+      <>
         <div
           onClick={event => onSortRequested('asc', event)}
           onTouchEnd={event => onSortRequested('asc', event)}
           className={`customSortDownLabel ${ascSort}`}
+          role="button"
+          tabIndex="0"
         >
-          <i className="fa fa-long-arrow-alt-down"></i>
+          <i className="fa fa-long-arrow-alt-down" />
         </div>
         <div
           onClick={event => onSortRequested('desc', event)}
           onTouchEnd={event => onSortRequested('desc', event)}
           className={`customSortUpLabel ${descSort}`}
+          role="button"
+          tabIndex="0"
         >
-          <i className="fa fa-long-arrow-alt-up"></i>
+          <i className="fa fa-long-arrow-alt-up" />
         </div>
         <div
           onClick={event => onSortRequested('', event)}
           onTouchEnd={event => onSortRequested('', event)}
           className={`customSortRemoveLabel ${noSort}`}
+          role="button"
+          tabIndex="0"
         >
-          <i className="fa fa-times"></i>
+          <i className="fa fa-times" />
         </div>
-      </React.Fragment>
+      </>
     );
   }
 
@@ -76,8 +82,10 @@ export default props => {
         ref={refButton}
         className="customHeaderMenuButton"
         onClick={() => onMenuClicked()}
+        role="button"
+        tabIndex="0"
       >
-        <i className={`fa ${props.menuIcon}`}></i>
+        <i className={`fa ${props.menuIcon}`} />
       </div>
       <div ref={refLabel} className="customHeaderLabel">
         {props.displayName}

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
@@ -1,70 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 
 export default props => {
-  const [ascSort, setAscSort] = useState('inactive');
-  const [descSort, setDescSort] = useState('inactive');
-  const [noSort, setNoSort] = useState('inactive');
   const refButton = useRef(null);
   const refLabel = useRef(null);
 
   const onMenuClicked = () => {
     props.showColumnMenu(refButton.current);
   };
-
-  const onSortChanged = () => {
-    setAscSort(props.column.isSortAscending() ? 'active' : 'inactive');
-    setDescSort(props.column.isSortDescending() ? 'active' : 'inactive');
-    setNoSort(
-      !props.column.isSortAscending() && !props.column.isSortDescending()
-        ? 'active'
-        : 'inactive',
-    );
-  };
-
-  const onSortRequested = (order, event) => {
-    props.setSort(order, event.shiftKey);
-  };
-
-  useEffect(() => {
-    props.column.addEventListener('sortChanged', onSortChanged);
-    onSortChanged();
-  }, []);
-
-  let sort = null;
-
-  if (props.enableSorting) {
-    sort = (
-      <>
-        <div
-          onClick={event => onSortRequested('asc', event)}
-          onTouchEnd={event => onSortRequested('asc', event)}
-          className={`customSortDownLabel ${ascSort}`}
-          role="button"
-          tabIndex="0"
-        >
-          <i className="fa fa-long-arrow-alt-down" />
-        </div>
-        <div
-          onClick={event => onSortRequested('desc', event)}
-          onTouchEnd={event => onSortRequested('desc', event)}
-          className={`customSortUpLabel ${descSort}`}
-          role="button"
-          tabIndex="0"
-        >
-          <i className="fa fa-long-arrow-alt-up" />
-        </div>
-        <div
-          onClick={event => onSortRequested('', event)}
-          onTouchEnd={event => onSortRequested('', event)}
-          className={`customSortRemoveLabel ${noSort}`}
-          role="button"
-          tabIndex="0"
-        >
-          <i className="fa fa-times" />
-        </div>
-      </>
-    );
-  }
 
   return (
     <div className="headerWrapper">
@@ -75,12 +17,11 @@ export default props => {
         role="button"
         tabIndex="0"
       >
-        <i className={`fa ${props.menuIcon}`} />
+        <i className="fa fa-bars" />
       </div>
       <div ref={refLabel} className="customHeaderLabel">
         {props.displayName}
       </div>
-      {sort}
     </div>
   );
 };

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 
 export default props => {
   const refButton = useRef(null);

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
@@ -30,12 +30,6 @@ export default props => {
     onSortChanged();
   }, []);
 
-  useEffect(() => {
-    if (!refLabel.current) {
-      return;
-    }
-  }, [refLabel]);
-
   let sort = null;
 
   if (props.enableSorting) {

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
@@ -1,0 +1,65 @@
+import React, {useEffect, useRef, useState} from 'react';
+
+export default props => {
+    const [ascSort, setAscSort] = useState('inactive');
+    const [descSort, setDescSort] = useState('inactive');
+    const [noSort, setNoSort] = useState('inactive');
+    const refButton = useRef(null);
+    const refLabel = useRef(null);
+
+    const onMenuClicked = () => {
+        props.showColumnMenu(refButton.current);
+    }
+
+    const onSortChanged = () => {
+        setAscSort(props.column.isSortAscending() ? 'active' : 'inactive');
+        setDescSort(props.column.isSortDescending() ? 'active' : 'inactive');
+        setNoSort(!props.column.isSortAscending() && !props.column.isSortDescending() ? 'active' : 'inactive');
+    }
+
+    const onSortRequested = (order, event) => {
+        props.setSort(order, event.shiftKey);
+    }
+
+    useEffect(() => {
+        props.column.addEventListener('sortChanged', onSortChanged);
+        onSortChanged()
+    }, []);
+
+    useEffect(() => {
+        if (!refLabel.current) { return; }
+        props.setTooltip(props.displayName, () => refLabel.current.scrollWidth > refLabel.current.clientWidth);
+    }, [refLabel])
+
+    let sort = null;
+
+    if (props.enableSorting) {
+        sort =
+            <React.Fragment>
+                <div onClick={event => onSortRequested('asc', event)} onTouchEnd={event => onSortRequested('asc', event)}
+                     className={`customSortDownLabel ${ascSort}`}>
+                <i className="fa fa-long-arrow-alt-down"></i>
+                </div>
+                <div onClick={event => onSortRequested('desc', event)} onTouchEnd={event => onSortRequested('desc', event)}
+                     className={`customSortUpLabel ${descSort}`}>
+                <i className="fa fa-long-arrow-alt-up"></i>
+                </div>
+                <div onClick={event => onSortRequested('', event)} onTouchEnd={event => onSortRequested('', event)}
+                     className={`customSortRemoveLabel ${noSort}`}>
+                <i className="fa fa-times"></i>
+                </div>
+            </React.Fragment>;
+    }
+
+    return (
+        <div className="headerWrapper">
+            <div ref={refButton}
+                className="customHeaderMenuButton"
+                onClick={() => onMenuClicked()}>
+            <i className={`fa ${props.menuIcon}`}></i>
+            </div>
+            <div ref={refLabel} className="customHeaderLabel">{props.displayName}</div>
+            {sort}
+        </div>
+    );
+};

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
@@ -1,65 +1,88 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 export default props => {
-    const [ascSort, setAscSort] = useState('inactive');
-    const [descSort, setDescSort] = useState('inactive');
-    const [noSort, setNoSort] = useState('inactive');
-    const refButton = useRef(null);
-    const refLabel = useRef(null);
+  const [ascSort, setAscSort] = useState('inactive');
+  const [descSort, setDescSort] = useState('inactive');
+  const [noSort, setNoSort] = useState('inactive');
+  const refButton = useRef(null);
+  const refLabel = useRef(null);
 
-    const onMenuClicked = () => {
-        props.showColumnMenu(refButton.current);
-    }
+  const onMenuClicked = () => {
+    props.showColumnMenu(refButton.current);
+  };
 
-    const onSortChanged = () => {
-        setAscSort(props.column.isSortAscending() ? 'active' : 'inactive');
-        setDescSort(props.column.isSortDescending() ? 'active' : 'inactive');
-        setNoSort(!props.column.isSortAscending() && !props.column.isSortDescending() ? 'active' : 'inactive');
-    }
-
-    const onSortRequested = (order, event) => {
-        props.setSort(order, event.shiftKey);
-    }
-
-    useEffect(() => {
-        props.column.addEventListener('sortChanged', onSortChanged);
-        onSortChanged()
-    }, []);
-
-    useEffect(() => {
-        if (!refLabel.current) { return; }
-        props.setTooltip(props.displayName, () => refLabel.current.scrollWidth > refLabel.current.clientWidth);
-    }, [refLabel])
-
-    let sort = null;
-
-    if (props.enableSorting) {
-        sort =
-            <React.Fragment>
-                <div onClick={event => onSortRequested('asc', event)} onTouchEnd={event => onSortRequested('asc', event)}
-                     className={`customSortDownLabel ${ascSort}`}>
-                <i className="fa fa-long-arrow-alt-down"></i>
-                </div>
-                <div onClick={event => onSortRequested('desc', event)} onTouchEnd={event => onSortRequested('desc', event)}
-                     className={`customSortUpLabel ${descSort}`}>
-                <i className="fa fa-long-arrow-alt-up"></i>
-                </div>
-                <div onClick={event => onSortRequested('', event)} onTouchEnd={event => onSortRequested('', event)}
-                     className={`customSortRemoveLabel ${noSort}`}>
-                <i className="fa fa-times"></i>
-                </div>
-            </React.Fragment>;
-    }
-
-    return (
-        <div className="headerWrapper">
-            <div ref={refButton}
-                className="customHeaderMenuButton"
-                onClick={() => onMenuClicked()}>
-            <i className={`fa ${props.menuIcon}`}></i>
-            </div>
-            <div ref={refLabel} className="customHeaderLabel">{props.displayName}</div>
-            {sort}
-        </div>
+  const onSortChanged = () => {
+    setAscSort(props.column.isSortAscending() ? 'active' : 'inactive');
+    setDescSort(props.column.isSortDescending() ? 'active' : 'inactive');
+    setNoSort(
+      !props.column.isSortAscending() && !props.column.isSortDescending()
+        ? 'active'
+        : 'inactive',
     );
+  };
+
+  const onSortRequested = (order, event) => {
+    props.setSort(order, event.shiftKey);
+  };
+
+  useEffect(() => {
+    props.column.addEventListener('sortChanged', onSortChanged);
+    onSortChanged();
+  }, []);
+
+  useEffect(() => {
+    if (!refLabel.current) {
+      return;
+    }
+    props.setTooltip(
+      props.displayName,
+      () => refLabel.current.scrollWidth > refLabel.current.clientWidth,
+    );
+  }, [refLabel]);
+
+  let sort = null;
+
+  if (props.enableSorting) {
+    sort = (
+      <React.Fragment>
+        <div
+          onClick={event => onSortRequested('asc', event)}
+          onTouchEnd={event => onSortRequested('asc', event)}
+          className={`customSortDownLabel ${ascSort}`}
+        >
+          <i className="fa fa-long-arrow-alt-down"></i>
+        </div>
+        <div
+          onClick={event => onSortRequested('desc', event)}
+          onTouchEnd={event => onSortRequested('desc', event)}
+          className={`customSortUpLabel ${descSort}`}
+        >
+          <i className="fa fa-long-arrow-alt-up"></i>
+        </div>
+        <div
+          onClick={event => onSortRequested('', event)}
+          onTouchEnd={event => onSortRequested('', event)}
+          className={`customSortRemoveLabel ${noSort}`}
+        >
+          <i className="fa fa-times"></i>
+        </div>
+      </React.Fragment>
+    );
+  }
+
+  return (
+    <div className="headerWrapper">
+      <div
+        ref={refButton}
+        className="customHeaderMenuButton"
+        onClick={() => onMenuClicked()}
+      >
+        <i className={`fa ${props.menuIcon}`}></i>
+      </div>
+      <div ref={refLabel} className="customHeaderLabel">
+        {props.displayName}
+      </div>
+      {sort}
+    </div>
+  );
 };

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeader.jsx
@@ -34,10 +34,6 @@ export default props => {
     if (!refLabel.current) {
       return;
     }
-    props.setTooltip(
-      props.displayName,
-      () => refLabel.current.scrollWidth > refLabel.current.clientWidth,
-    );
   }, [refLabel]);
 
   let sort = null;

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeaderStyles.css
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeaderStyles.css
@@ -1,0 +1,23 @@
+.headerWrapper {
+    display: flex;
+    overflow: hidden;
+    gap: 0.5rem;
+  }
+  
+.customHeaderLabel {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  
+.customSortRemoveLabel {
+    font-size: 11px;
+  }
+  
+.active {
+    color: cornflowerblue;
+  }
+
+.headerStyles {
+    display: flex;
+    flex-direction: row;
+  }

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeaderStyles.css
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeaderStyles.css
@@ -1,23 +1,23 @@
 .headerWrapper {
-    display: flex;
-    overflow: hidden;
-    gap: 0.5rem;
-  }
-  
+  display: flex;
+  overflow: hidden;
+  gap: 0.5rem;
+}
+
 .customHeaderLabel {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .customSortRemoveLabel {
-    font-size: 11px;
-  }
-  
+  font-size: 11px;
+}
+
 .active {
-    color: cornflowerblue;
-  }
+  color: cornflowerblue;
+}
 
 .headerStyles {
-    display: flex;
-    flex-direction: row;
-  }
+  display: flex;
+  flex-direction: row;
+}

--- a/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeaderStyles.css
+++ b/superset-frontend/src/cccs-viz/plugins/plugin-chart-ag-grid/src/ag-grid/CustomHeader/customHeaderStyles.css
@@ -1,7 +1,7 @@
 .headerWrapper {
   display: flex;
   overflow: hidden;
-  gap: 0.5rem;
+  gap: 0.7rem;
 }
 
 .customHeaderLabel {


### PR DESCRIPTION
### SUMMARY
Simon requested that the hamburger menu for ag grid be placed directly to the right of the text in the header so it is always accessible regardless of the cell's width. This change is feasible with Ag Grid through the creation of a custom header component.  

### TESTING INSTRUCTIONS
Currently deployed on Superset-Stg with image tag: bug_cldn-2053_20240612224119_b10315

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
