### PR TITLE
sections.legacyRegularTime doesn't exist anymore

### DIFF
--- a/superset-frontend/src/filters/components/Adhoc/controlPanel.ts
+++ b/superset-frontend/src/filters/components/Adhoc/controlPanel.ts
@@ -16,16 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { ControlPanelConfig } from '@superset-ui/chart-controls';
 import { t } from '@superset-ui/core';
-import { ControlPanelConfig, sections } from '@superset-ui/chart-controls';
 import { DEFAULT_FORM_DATA } from './types';
 
 const { enableEmptyFilter } = DEFAULT_FORM_DATA;
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
-    // @ts-ignore
-    sections.legacyRegularTime,
     {
       label: t('UI Configuration'),
       expanded: true,


### PR DESCRIPTION
sections.legacyRegularTime doesn't exist anymore, advice is to just remove it. I gave it a test and it seems fine and fixes our adhoc filter.