### PR TITLE
CLDN-2651 Add Prometheus Flask exporter

### DIFF
--- a/cccs-build/superset/requirements.txt
+++ b/cccs-build/superset/requirements.txt
@@ -13,3 +13,6 @@ typing-extensions>=4, <5
 
 # Required for Gunicorn
 gevent
+
+# Metrics
+prometheus-flask-exporter==0.23.2

--- a/superset/app.py
+++ b/superset/app.py
@@ -36,6 +36,13 @@ def create_app(superset_config_module: Optional[str] = None) -> Flask:
         )
         app.config.from_object(config_module)
 
+        export_app_metrics = app.config.get("EXPORT_FLASK_METRICS", False)
+        if export_app_metrics:
+            from prometheus_flask_exporter import PrometheusMetrics
+            
+            metrics = PrometheusMetrics.for_app_factory()
+            metrics.init_app(app)
+
         app_initializer = app.config.get("APP_INITIALIZER", SupersetAppInitializer)(app)
         app_initializer.init_app()
 


### PR DESCRIPTION
Currently deployed in U-DEV using [this configuration](https://github.com/CybercentreCanada/hogwarts-superset-deployment/pull/55) (links to my draft PR in the superset-deployment repo)

This wee change enables Flask app metrics from the Superset web backend, everything else is through Helm. If for some reason this causes issues, we can shut this off by removing EXPORT_FLASK_METRICS from the deployed app config.