### PR TITLE
Add date support to Bubble charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/controlPanel.tsx
@@ -160,6 +160,14 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'xAxisTimeFormat',
+            config: {
+              ...sharedControls.x_axis_time_format,
+            },
+          },
+        ],
+        [
+          {
             name: 'logXAxis',
             config: {
               type: 'CheckboxControl',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
@@ -179,10 +179,13 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
 
   normalizeSymbolSize(series, maxBubbleSize);
 
+  // const xAxisFormatter = getNumberFormatter(xAxisFormat);
+  // CCCS code - format numbers or dates
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
       ? getTimeFormatter(xAxisTimeFormat)
       : getNumberFormatter(xAxisFormat);
+  // end CCCS code
   const yAxisFormatter = getNumberFormatter(yAxisFormat);
   const tooltipSizeFormatter = getNumberFormatter(tooltipSizeFormat);
 
@@ -201,11 +204,14 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
     convertInteger(xAxisTitleMargin),
   );
 
+  // const xAxisType = logXAxis ? AxisType.Log : AxisType.Value;
+  // CCCS code - add temporal axis type
   const xAxisType = logXAxis
     ? AxisType.Log
     : xAxisDataType === GenericDataType.Temporal
       ? AxisType.Time
       : AxisType.Value;
+  // end CCCS code
   const echartOptions: EChartsCoreOption = {
     series,
     xAxis: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
@@ -26,11 +26,18 @@ import {
   getMetricLabel,
   NumberFormatter,
   tooltipHtml,
+  GenericDataType,
+  TimeFormatter,
+  getTimeFormatter,
 } from '@superset-ui/core';
 import { EchartsBubbleChartProps, EchartsBubbleFormData } from './types';
 import { DEFAULT_FORM_DATA, MINIMUM_BUBBLE_SIZE } from './constants';
 import { defaultGrid } from '../defaults';
-import { getLegendProps, getMinAndMaxFromBounds } from '../utils/series';
+import {
+  getColtypesMapping,
+  getLegendProps,
+  getMinAndMaxFromBounds,
+} from '../utils/series';
 import { Refs } from '../types';
 import { parseAxisBound } from '../utils/controls';
 import { getDefaultTooltip } from '../utils/tooltip';
@@ -76,7 +83,7 @@ export function formatTooltip(
   xAxisLabel: string,
   yAxisLabel: string,
   sizeLabel: string,
-  xAxisFormatter: NumberFormatter,
+  xAxisFormatter: NumberFormatter | TimeFormatter,
   yAxisFormatter: NumberFormatter,
   tooltipSizeFormatter: NumberFormatter,
 ) {
@@ -98,6 +105,7 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
   const { height, width, hooks, queriesData, formData, inContextMenu, theme } =
     chartProps;
 
+  const [queryData] = queriesData;
   const { data = [] } = queriesData[0];
   const {
     x,
@@ -110,6 +118,7 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
     xAxisLabel: bubbleXAxisTitle,
     yAxisLabel: bubbleYAxisTitle,
     xAxisBounds,
+    xAxisTimeFormat,
     xAxisFormat,
     yAxisFormat,
     yAxisBounds,
@@ -134,10 +143,12 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
 
   const legends = new Set<string>();
   const series: ScatterSeriesOption[] = [];
+  const dataTypes = getColtypesMapping(queryData);
 
   const xAxisLabel: string = getMetricLabel(x);
   const yAxisLabel: string = getMetricLabel(y);
   const sizeLabel: string = getMetricLabel(size);
+  const xAxisDataType = dataTypes?.[xAxisLabel];
 
   const refs: Refs = {};
 
@@ -168,7 +179,10 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
 
   normalizeSymbolSize(series, maxBubbleSize);
 
-  const xAxisFormatter = getNumberFormatter(xAxisFormat);
+  const xAxisFormatter =
+    xAxisDataType === GenericDataType.Temporal
+      ? getTimeFormatter(xAxisTimeFormat)
+      : getNumberFormatter(xAxisFormat);
   const yAxisFormatter = getNumberFormatter(yAxisFormat);
   const tooltipSizeFormatter = getNumberFormatter(tooltipSizeFormat);
 
@@ -187,7 +201,11 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
     convertInteger(xAxisTitleMargin),
   );
 
-  const xAxisType = logXAxis ? AxisType.Log : AxisType.Value;
+  const xAxisType = logXAxis
+    ? AxisType.Log
+    : xAxisDataType === GenericDataType.Temporal
+      ? AxisType.Time
+      : AxisType.Value;
   const echartOptions: EChartsCoreOption = {
     series,
     xAxis: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/types.ts
@@ -31,6 +31,7 @@ export type EchartsBubbleFormData = QueryFormData &
   LegendFormData & {
     series?: string;
     entity: string;
+    xAxisTimeFormat: string;
     xAxisFormat: string;
     yAXisFormat: string;
     logXAxis: boolean;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/types.ts
@@ -31,7 +31,7 @@ export type EchartsBubbleFormData = QueryFormData &
   LegendFormData & {
     series?: string;
     entity: string;
-    xAxisTimeFormat: string;
+    xAxisTimeFormat: string; // CCCS addition
     xAxisFormat: string;
     yAXisFormat: string;
     logXAxis: boolean;


### PR DESCRIPTION
By user request! It is understandable to assume that Bubble charts would display datetimes properly since those charts are advertised in-app with the tag "time." This is very much a duct-tape solution and I will not be considering contributing this upstream.

tl;dr I've added a check for temporal-ness to the Bubble chart X-axis, and a form option to set the date display format.

Screenshot from local:
<img width="1529" height="584" alt="Screenshot 2026-03-26 164750" src="https://github.com/user-attachments/assets/9477d1b6-8c61-403e-9803-7650201aa0a2" />
