### PR TITLE
NOISSUE Fix Bubble chart label rotation

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
@@ -215,13 +215,12 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
   const echartOptions: EChartsCoreOption = {
     series,
     xAxis: {
-      axisLabel: { formatter: xAxisFormatter },
+      axisLabel: { formatter: xAxisFormatter, rotate: xAxisLabelRotation },
       splitLine: {
         lineStyle: {
           type: 'dashed',
         },
       },
-      nameRotate: xAxisLabelRotation,
       interval: xAxisLabelInterval,
       scale: true,
       name: bubbleXAxisTitle,
@@ -234,13 +233,12 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
       ...getMinAndMaxFromBounds(xAxisType, truncateXAxis, xAxisMin, xAxisMax),
     },
     yAxis: {
-      axisLabel: { formatter: yAxisFormatter },
+      axisLabel: { formatter: yAxisFormatter, rotate: yAxisLabelRotation },
       splitLine: {
         lineStyle: {
           type: 'dashed',
         },
       },
-      nameRotate: yAxisLabelRotation,
       scale: truncateYAxis,
       name: bubbleYAxisTitle,
       nameLocation: 'middle',


### PR DESCRIPTION
This must've been left over from an Echarts upgrade, every other chart is correctly using `[xy]Axis.axisLabel.rotate` per [the docs](https://echarts.apache.org/en/option.html#yAxis.axisLabel.rotate), e.g. from Heatmap:
<img width="947" height="229" alt="image" src="https://github.com/user-attachments/assets/0f03552b-47e1-4025-a171-7419f7541483" />

Screenshot from local to prove it works:
<img width="1492" height="1144" alt="image" src="https://github.com/user-attachments/assets/a434d27f-f08b-43d9-a04b-b2a964d37e6b" />
